### PR TITLE
Play 2.4 Enhancement

### DIFF
--- a/play-2.4/swagger-play2/README.md
+++ b/play-2.4/swagger-play2/README.md
@@ -95,3 +95,21 @@ This will "attach" the /api-docs/pet api to the swagger resource listing, and th
 Swagger for play has two types of `ApiParam`s--they are `ApiParam` and `ApiParamImplicit`.  The distinction is that some
 paramaters (variables) are passed to the method implicitly by the framework.  ALL body parameters need to be described
 with `ApiParamImplicit` annotations.  If they are `queryParam`s or `pathParam`s, you can use `ApiParam` annotations.
+
+
+# application.conf - config options
+```
+api.version (String) - version of API | default: "beta"
+swagger.api.basepath (String) - base url | default: "http://localhost:9000"
+swagger.filter (String) - classname of swagger filter | default: empty
+swagger.api.info = {
+  contact : (String) - Contact Information | default : empty,
+  description : (String) - Description | default : empty,
+  title : (String) - Title | default : empty,
+  termsOfService : (String) - Terms Of Service | default : empty,
+  license : (String) - Terms Of Service | default : empty,
+  licenseUrl : (String) - Terms Of Service | default : empty
+}
+
+```
+

--- a/play-2.4/swagger-play2/app/controllers/ApiHelpController.scala
+++ b/play-2.4/swagger-play2/app/controllers/ApiHelpController.scala
@@ -63,7 +63,7 @@ class ErrorResponse(@XmlElement var code: Int, @XmlElement var message: String) 
   def setMessage(message: String) = this.message = message
 }
 
-object ApiHelpController extends SwaggerBaseApiController {
+class ApiHelpController extends SwaggerBaseApiController {
 
   def getResources = Action {
     request =>
@@ -146,7 +146,7 @@ class SwaggerBaseApiController extends Controller {
         Logger("swagger").debug("reference: %s".format(ref.toString))
     }
     ResourceListing(
-      ConfigFactory.config.getApiVersion, 
+      ConfigFactory.config.getApiVersion,
       ConfigFactory.config.getSwaggerVersion,
       references,
       ConfigFactory.config.authorizations,

--- a/play-2.4/swagger-play2/app/play/modules/swagger/SwaggerModule.scala
+++ b/play-2.4/swagger-play2/app/play/modules/swagger/SwaggerModule.scala
@@ -1,0 +1,15 @@
+package play.modules.swagger
+
+
+import controllers.ApiHelpController
+import play.api.inject.{Binding, Module}
+import play.api.{Configuration, Environment}
+
+class SwaggerModule extends Module {
+
+  override def bindings(environment: Environment, configuration: Configuration): Seq[Binding[_]] =  Seq(
+    bind[SwaggerPlugin].toProvider[SwaggerPluginProvider].eagerly(),
+    bind[ApiHelpController].toSelf.eagerly()
+  )
+
+}

--- a/play-2.4/swagger-play2/app/play/modules/swagger/SwaggerPlugin.scala
+++ b/play-2.4/swagger-play2/app/play/modules/swagger/SwaggerPlugin.scala
@@ -16,66 +16,8 @@
 
 package play.modules.swagger
 
-import com.wordnik.swagger.core.{SwaggerSpec, SwaggerContext}
-import play.api.{Logger, Application, Plugin}
-import play.api.Play._
-import com.wordnik.swagger.config.{FilterFactory, SwaggerConfig, ConfigFactory, ScannerFactory}
-import com.wordnik.swagger.reader.ClassReaders
-import com.wordnik.swagger.core.filter.SwaggerSpecFilter
+import play.api.Plugin
 
-class SwaggerPlugin(application: Application) extends Plugin {
+class SwaggerPlugin() extends Plugin {
 
-  override def onStart() {
-    Logger("swagger").info("Plugin - starting initialisation")
-
-    val apiVersion = current.configuration.getString("api.version") match {
-      case None => "beta"
-      case Some(value) => value
-    }
-
-    val basePath = current.configuration.getString("swagger.api.basepath") match {
-      case Some(e) if (e != "") => {
-        //ensure basepath is a valid URL, else throw an exception
-        try {
-          val basepathUrl = new java.net.URL(e)
-          Logger("swagger").info("Basepath configured as: %s".format(e))
-          e
-        } catch {
-          case ex: Exception =>
-            Logger("swagger").error("Misconfiguration - basepath not a valid URL: %s. Swagger plugin abandoning initialisation".format(e))
-            throw ex
-        }
-      }
-      case _ => "http://localhost"
-    }
-
-    SwaggerContext.registerClassLoader(current.classloader)
-    ConfigFactory.config.apiVersion = apiVersion
-    ConfigFactory.config.basePath = basePath
-    ScannerFactory.setScanner(new PlayApiScanner(Some(current.routes)))
-    ClassReaders.reader = Some(new PlayApiReader(Some(current.routes)))
-
-    current.configuration.getString("swagger.filter") match {
-      case Some(e) if (e != "") => {
-        try {
-          FilterFactory.filter = SwaggerContext.loadClass(e).newInstance.asInstanceOf[SwaggerSpecFilter]
-          Logger("swagger").info("Setting swagger.filter to %s".format(e))
-        }
-        catch {
-          case ex: Exception => Logger("swagger").error("Failed to load filter " + e, ex)
-        }
-      }
-      case _ =>
-    }
-
-    val docRoot = ""
-    ApiListingCache.listing(docRoot)
-
-    Logger("swagger").info("Plugin - initialization done")
-  }
-
-  override def onStop() {
-    ApiListingCache.cache = None
-    Logger("swagger").info("Plugin - stopped");
-  }
 }

--- a/play-2.4/swagger-play2/app/play/modules/swagger/SwaggerPluginProvider.scala
+++ b/play-2.4/swagger-play2/app/play/modules/swagger/SwaggerPluginProvider.scala
@@ -1,0 +1,135 @@
+package play.modules.swagger
+import java.net.URL
+import javax.inject.{Inject, Provider}
+
+import com.wordnik.swagger.config.{FilterFactory, ScannerFactory, ConfigFactory}
+import com.wordnik.swagger.core.SwaggerContext
+import com.wordnik.swagger.core.filter.SwaggerSpecFilter
+import com.wordnik.swagger.model.ApiInfo
+import com.wordnik.swagger.reader.ClassReaders
+import play.api.inject.ApplicationLifecycle
+import play.api.{Logger, Application}
+import play.api.routing.Router
+import scala.concurrent.ExecutionContext.Implicits.global
+
+import scala.concurrent.Future
+
+class SwaggerPluginProvider extends Provider[SwaggerPlugin] {
+
+  val logger = Logger("swagger")
+
+  @Inject
+  private var router: Router = _
+
+  @Inject
+  private var app: Application = _
+
+  @Inject
+  private var lifecycle: ApplicationLifecycle = _
+
+  override def get(): SwaggerPlugin = {
+    lifecycle.addStopHook(() => Future {
+      onStop()
+    })
+
+    onStart()
+  }
+
+  def onStart(): SwaggerPlugin = {
+    val config = app.configuration
+    logger.info("Swagger - starting initialisation...")
+
+    val apiVersion = config.getString("api.version") match {
+      case None => "beta"
+      case Some(value) => value
+    }
+
+    val basePath = config.getString("swagger.api.basepath")
+      .filter(path => !path.isEmpty)
+      .map(getPathUrl(_))
+      .getOrElse("http://localhost:9000")
+
+    val title = config.getString("swagger.api.info.title") match {
+      case None => ""
+      case Some(value)=> value
+    }
+
+    val description = config.getString("swagger.api.info.description") match {
+      case None => ""
+      case Some(value)=> value
+    }
+
+    val termsOfServiceUrl = config.getString("swagger.api.info.termsOfServiceUrl") match {
+      case None => ""
+      case Some(value)=> value
+    }
+
+    val contact = config.getString("swagger.api.info.contact") match {
+      case None => ""
+      case Some(value)=> value
+    }
+
+    val license = config.getString("swagger.api.info.license") match {
+      case None => ""
+      case Some(value)=> value
+    }
+
+    val licenseUrl = config.getString("swagger.api.info.licenseUrl") match {
+      case None => ""
+      case Some(value)=> value
+    }
+
+    ConfigFactory.config.setApiInfo(new ApiInfo(title, description, termsOfServiceUrl, contact, license, licenseUrl));
+
+    SwaggerContext.registerClassLoader(app.classloader)
+    ConfigFactory.config.setApiVersion(apiVersion)
+    ConfigFactory.config.setBasePath(basePath)
+    ScannerFactory.setScanner(new PlayApiScanner(Option(router)))
+    ClassReaders.reader = Some(new PlayApiReader(Option(router)))
+
+    app.configuration.getString("swagger.filter") match {
+      case Some(e) if (e != "") => {
+        try {
+          FilterFactory.filter = SwaggerContext.loadClass(e).newInstance.asInstanceOf[SwaggerSpecFilter]
+          Logger("swagger").info("Setting swagger.filter to %s".format(e))
+        }
+        catch {
+          case ex: Exception => Logger("swagger").error("Failed to load filter " + e, ex)
+        }
+      }
+      case _ =>
+    }
+
+    val docRoot = ""
+    ApiListingCache.listing(docRoot)
+
+    logger.info("Swagger - initialization done.")
+    new SwaggerPlugin()
+  }
+
+  def onStop() {
+    ApiListingCache.cache = None
+    logger.info("Swagger - stopped.")
+  }
+
+  def loadFilter(filterClass: String): Unit = {
+    try {
+      FilterFactory.filter = SwaggerContext.loadClass(filterClass).newInstance.asInstanceOf[SwaggerSpecFilter]
+      logger.info(s"Setting swagger.filter to $filterClass")
+    } catch {
+      case ex: Exception =>logger.error(s"Failed to load filter:$filterClass", ex)
+    }
+  }
+  def getPathUrl(path: String): String = {
+    try {
+      val basePathUrl = new URL(path)
+      logger.info(s"Basepath configured as:$path")
+      path
+    } catch {
+      case ex: Exception =>
+        logger.error(s"Misconfiguration - basepath not a valid URL:$path. Swagger abandoning initialisation!")
+        throw ex
+    }
+  }
+
+}

--- a/play-2.4/swagger-play2/project/Build.scala
+++ b/play-2.4/swagger-play2/project/Build.scala
@@ -1,9 +1,7 @@
-import sbt._
-import Keys._
-import play.sbt.Play.autoImport._
-import play.sbt.PlayScala
-import PlayKeys._
 import play.ebean.sbt.PlayEbean
+import play.sbt.PlayScala
+import sbt.Keys._
+import sbt._
 
 object ApplicationBuild extends Build {
   val appName = "swagger-play2"
@@ -77,5 +75,6 @@ object ApplicationBuild extends Build {
       "sonatype-releases" at "https://oss.sonatype.org/content/repositories/releases",
       "java-net" at "http://download.java.net/maven/2",
       "Typesafe Snapshots" at "http://repo.typesafe.com/typesafe/snapshots/",
-      "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"))
+      "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/",
+      "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases"))
 }


### PR DESCRIPTION
Fixes the following issue by using modules instead of plugins. https://github.com/swagger-api/swagger-core/issues/1144.

It also allows for the API Info to be set in the application.conf
# application.conf - config options

```
api.version (String) - version of API | default: "beta"
swagger.api.basepath (String) - base url | default: "http://localhost:9000"
swagger.filter (String) - classname of swagger filter | default: empty
swagger.api.info = {
  contact : (String) - Contact Information | default : empty,
  description : (String) - Description | default : empty,
  title : (String) - Title | default : empty,
  termsOfService : (String) - Terms Of Service | default : empty,
  license : (String) - Terms Of Service | default : empty,
  licenseUrl : (String) - Terms Of Service | default : empty
}

```
