### PR TITLE
Fix routes replace rule

### DIFF
--- a/play-2.1/swagger-play2/app/play/modules/swagger/PlayApiReader.scala
+++ b/play-2.1/swagger-play2/app/play/modules/swagger/PlayApiReader.scala
@@ -26,7 +26,7 @@ case class RouteEntry(httpMethod: String, path: String)
 
 object SwaggerUtils {
   def convertPathString(str: String) = {
-    str.replaceAll( """<\[[\^/\d-\w]*\]\+>""", "}").replaceAll("\\$", "{")
+    str.replaceAll("""<[^>]+>""", "}").replaceAll("\\$", "{")
   }
 }
 

--- a/play-2.2/swagger-play2/app/play/modules/swagger/PlayApiReader.scala
+++ b/play-2.2/swagger-play2/app/play/modules/swagger/PlayApiReader.scala
@@ -26,7 +26,7 @@ case class RouteEntry(httpMethod: String, path: String)
 
 object SwaggerUtils {
   def convertPathString(str: String) = {
-    str.replaceAll( """<\[[\^/\d-\w]*\]\+>""", "}").replaceAll("\\$", "{")
+    str.replaceAll("""<[^>]+>""", "}").replaceAll("\\$", "{")
   }
 }
 

--- a/play-2.3/swagger-play2/app/play/modules/swagger/PlayApiReader.scala
+++ b/play-2.3/swagger-play2/app/play/modules/swagger/PlayApiReader.scala
@@ -26,7 +26,7 @@ case class RouteEntry(httpMethod: String, path: String)
 
 object SwaggerUtils {
   def convertPathString(str: String) = {
-    str.replaceAll( """<\[[\^/\d-\w]*\]\+>""", "}").replaceAll("\\$", "{")
+    str.replaceAll("""<[^>]+>""", "}").replaceAll("\\$", "{")
   }
 }
 

--- a/play-2.4/swagger-play2/app/play/modules/swagger/PlayApiReader.scala
+++ b/play-2.4/swagger-play2/app/play/modules/swagger/PlayApiReader.scala
@@ -26,7 +26,7 @@ case class RouteEntry(httpMethod: String, path: String)
 
 object SwaggerUtils {
   def convertPathString(str: String) = {
-    str.replaceAll( """<\[[\^/\d-\w]*\]\+>""", "}").replaceAll("\\$", "{")
+    str.replaceAll("""<[^>]+>""", "}").replaceAll("\\$", "{")
   }
 }
 


### PR DESCRIPTION
Routes rule by play is very simple https://github.com/playframework/playframework/blob/master/framework/src/routes-compiler/src/main/scala/play/routes/compiler/RoutesFileParser.scala#L229 

It havent to limit characters in <>. Now defenition is too strict, e.g, we cannot use _ in <>.

I checked this fix in play 2.3.6 and below routes description.

```
POST     /api/v1/$database_id<[^_].*>/abc    controllers.api.v1.Application.abc(database_id)
```

before

```
/api/v1/{database_id<[^_].*>/abc
```

after

```
/api/v1/{database_id}/abc
```
