### PR TITLE
Play 2.2 and newer use libraryDependencies instead of appDependencies

### DIFF
--- a/play-2.2/swagger-play2/README.md
+++ b/play-2.2/swagger-play2/README.md
@@ -13,7 +13,7 @@ Usage
 You can depend on pre-built libraries in maven central by adding the following dependency:
 
 ```
-val appDependencies: Seq[sbt.ModuleID] = Seq(
+libraryDependencies ++= Seq(
   "com.wordnik" %% "swagger-play2" % "1.3.6"
 )
 ```

--- a/play-2.3/swagger-play2/README.md
+++ b/play-2.3/swagger-play2/README.md
@@ -20,7 +20,7 @@ Usage
 You can depend on pre-built libraries in maven central by adding the following dependency:
 
 ```
-val appDependencies: Seq[sbt.ModuleID] = Seq(
+libraryDependencies ++= Seq(
   "com.wordnik" %% "swagger-play2" % "1.3.12"
 )
 ```

--- a/play-2.4/swagger-play2/README.md
+++ b/play-2.4/swagger-play2/README.md
@@ -24,7 +24,7 @@ Usage
 You can depend on pre-built libraries in maven central by adding the following dependency:
 
 ```
-val appDependencies: Seq[sbt.ModuleID] = Seq(
+libraryDependencies ++= Seq(
   "com.wordnik" %% "swagger-play2" % "1.3.13"
 )
 ```


### PR DESCRIPTION
I'm looking at [the README](https://github.com/swagger-api/swagger-play/tree/master/play-2.4/swagger-play2) and it seems to use a very outdated syntax:

```
val appDependencies: Seq[sbt.ModuleID] = Seq(
  "com.wordnik" %% "swagger-play2" % "1.3.13"
)
```

Play 2.1 used this syntax:
https://www.playframework.com/documentation/2.1.x/SBTDependencies

Play 2.2 and newer use `libraryDependencies` instead:
https://www.playframework.com/documentation/2.2.x/SBTDependencies
