### PR TITLE
Support custom routes files

### DIFF
--- a/play-2.4/swagger-play2/app/play/modules/swagger/SwaggerPlugin.scala
+++ b/play-2.4/swagger-play2/app/play/modules/swagger/SwaggerPlugin.scala
@@ -80,6 +80,14 @@ class SwaggerPluginImpl @Inject()(lifecycle: ApplicationLifecycle, router: Route
     case Some(value)=> value
   }
 
+  val routesFile = config.underlying.hasPath("play.http.router") match {
+    case false => "routes"
+    case true => config.getString("play.http.router") match {
+      case None => "routes"
+      case Some(value)=> value.replace(".Routes", ".routes")
+    }
+  }
+
   SwaggerContext.registerClassLoader(app.classloader)
 
   var scanner = new PlayApiScanner()
@@ -99,8 +107,8 @@ class SwaggerPluginImpl @Inject()(lifecycle: ApplicationLifecycle, router: Route
 
   PlayConfigFactory.setConfig(swaggerConfig)
 
-  val routes ={
-    play.modules.swagger.routes.RoutesFileParser.parse(app.classloader,"routes","").right.get.collect {
+  val routes = {
+    play.modules.swagger.routes.RoutesFileParser.parse(app.classloader, routesFile, "").right.get.collect {
       case (prefix, route: PlayRoute) => {
         val routeName = s"${route.call.packageName}.${route.call.controller}$$.${route.call.method}"
         (prefix, route)

--- a/play-2.4/swagger-play2/build.sbt
+++ b/play-2.4/swagger-play2/build.sbt
@@ -11,9 +11,9 @@ libraryDependencies ++= Seq(
   "io.swagger"         % "swagger-core"               % "1.5.4",
   "io.swagger"        %% "swagger-scala-module"       % "1.0.0",
   "com.typesafe.play" %% "play-ebean"                 % "2.0.0"            % "test",
-  "org.specs2"        %% "specs2-core"                % "3.6"              % "test",
-  "org.specs2"        %% "specs2-mock"                % "3.6"              % "test",
-  "org.specs2"        %% "specs2-junit"               % "3.6"              % "test",
+  "org.specs2"        %% "specs2-core"                % "3.6.6"            % "test",
+  "org.specs2"        %% "specs2-mock"                % "3.6.6"            % "test",
+  "org.specs2"        %% "specs2-junit"               % "3.6.6"            % "test",
   "org.mockito"        % "mockito-core"               % "1.9.5"            % "test")
 
 publishTo <<= version { (v: String) =>


### PR DESCRIPTION
If the application defines a custom a routes file then use that - fixes #32.

I also had to add the bintray resolver so the scalaz artifact could be found -- I got a resolution error without this (perhaps others have it cached on their system?).
