### PR TITLE
fix #43 - Parameter types handling

### DIFF
--- a/play-2.4/swagger-play2/build.sbt
+++ b/play-2.4/swagger-play2/build.sbt
@@ -8,8 +8,8 @@ crossScalaVersions := Seq("2.11.6", "2.11.7")
 
 libraryDependencies ++= Seq(
   "org.slf4j"          % "slf4j-api"                  % "1.6.4",
-  "io.swagger"         % "swagger-core"               % "1.5.7",
-  "io.swagger"        %% "swagger-scala-module"       % "1.0.0",
+  "io.swagger"         % "swagger-core"               % "1.5.8-SNAPSHOT",
+  "io.swagger"        %% "swagger-scala-module"       % "1.0.2-SNAPSHOT",
   "com.typesafe.play" %% "routes-compiler"            % "2.4.6",
   "com.typesafe.play" %% "play-ebean"                 % "2.0.0"            % "test",
   "org.specs2"        %% "specs2-core"                % "3.6.6"            % "test",

--- a/play-2.4/swagger-play2/test/testdata/CatController.scala
+++ b/play-2.4/swagger-play2/test/testdata/CatController.scala
@@ -55,6 +55,18 @@ class CatController extends Controller {
     def no_route = Action {
       request => Ok("test case")
     }
+
+  @ApiOperation(value = "test issue #43",
+    nickname = "test issue #43_nick",
+    notes = "test issue #43_notes",
+    response = classOf[testdata.Cat],
+    responseContainer = "List",
+    httpMethod = "GET")
+  @ApiImplicitParams(Array(
+    new ApiImplicitParam(name = "test_issue_43_implicit_param", dataType = "Option[Int]", value = "test issue #43 implicit param", paramType = "query")))
+  def testIssue43(test_issue_43_param:  Option[Int]) = Action {
+    request => Ok("test issue #43")
+  }
 }
 
 case class Cat(id: Long, name: String)


### PR DESCRIPTION
fix #43
ref https://github.com/swagger-api/swagger-core/pull/1635
ref https://github.com/swagger-api/swagger-scala-module/pull/17

Solution for issues reported in #43; Depends on swagger-core PR https://github.com/swagger-api/swagger-core/pull/1635 and swagger-scala-module https://github.com/swagger-api/swagger-scala-module/pull/17 to provide a consistent fix for #43 and related.

swagger-core and swagger-scala-module dependencies versions need to be updated accordingly. merge sequence would be:
1. merge https://github.com/swagger-api/swagger-core/pull/1635
2. merge https://github.com/swagger-api/swagger-scala-module/pull/17
3. bump swagger-core and swagger-scala-module versions
4. update swagger-core and swagger-scala-module versions in build.sbt / merge PR

Note that ApiImplicitParam are always added to set of existing inferred params (defined in route).
