### PR TITLE
Upgrade lib version of playframework from '2.4' to '2.5.1

### DIFF
--- a/play-2.5/swagger-play2/.gitignore
+++ b/play-2.5/swagger-play2/.gitignore
@@ -1,0 +1,21 @@
+ass
+*.log
+
+.idea/
+.idea_modules/
+*.iml
+
+# sbt specific
+dist/*
+target/
+lib_managed/
+src_managed/
+project/boot/
+project/plugins/project/
+
+# Scala-IDE specific
+.scala_dependencies
+.project
+.settings
+.classpath
+# Scala-IDE specific

--- a/play-2.5/swagger-play2/README.md
+++ b/play-2.5/swagger-play2/README.md
@@ -1,0 +1,127 @@
+[![Build Status](https://travis-ci.org/rayyildiz/swagger-play.svg?branch=master)](https://travis-ci.org/rayyildiz/swagger-play)
+
+# Swagger Play2 Module
+
+## Overview
+This is a module to support the play2 framework from [playframework](http://www.playframework.org).  It is written in scala but can be used with either java or scala-based play2 applications.
+
+## Version History
+
+* swagger-play2 1.5.1 supports play 2.4 and swagger 2.0.  If you need swagger 1.2 support, use 1.3.13. If you need 2.2 support, use 1.3.7 or earlier.
+
+* swagger-play2 1.3.13 supports play 2.4.  If you need 2.2 support, use 1.3.7 or earlier.
+
+* swagger-play2 1.3.12 supports play 2.3.  If you need 2.2 support, use 1.3.7 or earlier.
+
+* swagger-play2 1.3.7 supports play 2.2.  If you need 2.1 support, please use 1.3.5 or earlier
+
+* swagger-play2 1.3.6 requires play 2.2.x.
+
+* swagger-play2 1.2.1 and greater support scala 2.10 and play 2.0 and 2.1.
+
+* swagger-play2 1.2.0 support scala 2.9.x and play 2.0, please use 1.2.0.
+
+Usage
+-----
+
+You can depend on pre-built libraries in maven central by adding the following dependency:
+
+```
+libraryDependencies ++= Seq(
+  "io.swagger" %% "swagger-play2" % "1.5.1"
+)
+```
+
+Or you can build from source.
+
+```
+cd modules/swagger-play2
+
+sbt publishLocal
+```
+
+### Adding Swagger to your Play2 app
+
+There are just a couple steps to integrate your Play2 app with swagger.
+
+1\. Add the Swagger module to your `application.conf`
+ 
+```
+play.modules.enabled += "play.modules.swagger.SwaggerModule"
+```
+ 
+2\. Add the resource listing to your routes file (you can read more about the resource listing [here](https://github.com/swagger-api/swagger-core/wiki/Resource-Listing))
+
+```
+
+GET     /swagger.json           controllers.ApiHelpController.getResources
+
+```
+
+3\. Annotate your REST endpoints with Swagger annotations. This allows the Swagger framework to create the [api-declaration](https://github.com/swagger-api/swagger-core/wiki/API-Declaration) automatically!
+
+In your controller for, say your "pet" resource:
+
+```scala
+@Api(value = "/pet", description = "Operations about pets")
+class PetApiController extends BaseApiController {
+
+  @ApiOperation(nickname = "getPetById", value = "Find pet by ID", notes = "Returns a pet", response = classOf[models.Pet], httpMethod = "GET")
+  @ApiResponses(Array(
+    new ApiResponse(code = 400, message = "Invalid ID supplied"),
+    new ApiResponse(code = 404, message = "Pet not found")))
+  def getPetById(
+    @ApiParam(value = "ID of the pet to fetch") @PathParam("id") id: String) = Action {
+
+  ...
+
+```
+
+What this does is the following:
+
+* Tells swagger that the methods in this controller should be described under the `/api-docs/pet` path
+
+* The Routes file tells swagger that this API listens to `/{id}`
+
+* Describes the operation as a `GET` with the documentation `Find pet by Id` with more detailed notes `Returns a pet ....`
+
+* Takes the param `id`, which is a datatype `string` and a `path` param
+
+* Returns error codes 400 and 404, with the messages provided
+
+In the routes file, you then wire this api as follows:
+
+```
+GET     /pet/:id                 controllers.PetApiController.getPetById(id)
+```
+
+This will "attach" the /api-docs/pet api to the swagger resource listing, and the method to the `getPetById` method above
+
+Please note that the minimum configuration needed to have a route/controller be exposed in swagger declaration is to have an `Api` annotation at class level.
+
+#### The ApiParam annotation
+
+Swagger for play has two types of `ApiParam`s--they are `ApiParam` and `ApiImplicitParam`.  The distinction is that some
+paramaters (variables) are passed to the method implicitly by the framework.  ALL body parameters need to be described
+with `ApiImplicitParam` annotations.  If they are `queryParam`s or `pathParam`s, you can use `ApiParam` annotations.
+
+
+# application.conf - config options
+```
+api.version (String) - version of API | default: "beta"
+swagger.api.basepath (String) - base url | default: "http://localhost:9000"
+swagger.filter (String) - classname of swagger filter | default: empty
+swagger.api.info = {
+  contact : (String) - Contact Information | default : empty,
+  description : (String) - Description | default : empty,
+  title : (String) - Title | default : empty,
+  termsOfService : (String) - Terms Of Service | default : empty,
+  license : (String) - Terms Of Service | default : empty,
+  licenseUrl : (String) - Terms Of Service | default : empty
+}
+```
+
+## Note on Dependency Injection
+This plugin works by default if your application uses Runtime dependency injection.
+
+Nevertheless, a helper is provided `SwaggerApplicationLoader` to ease the use of this plugin with Compile Time Dependency Injection. 

--- a/play-2.5/swagger-play2/app/controllers/ApiHelpController.scala
+++ b/play-2.5/swagger-play2/app/controllers/ApiHelpController.scala
@@ -1,0 +1,209 @@
+/**
+ * Copyright 2014 Reverb Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import play.api.mvc._
+import play.api.Logger
+import play.api.libs.iteratee.Enumerator
+import play.modules.swagger.ApiListingCache
+
+import javax.xml.bind.annotation._
+
+import java.io.StringWriter
+
+import io.swagger.util.Json
+import io.swagger.models.Swagger
+import io.swagger.core.filter.SpecFilter
+import io.swagger.config.FilterFactory
+
+import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
+
+object ErrorResponse {
+  val ERROR = 1
+  val WARNING = 2
+  val INFO = 3
+  val OK = 4
+  val TOO_BUSY = 5
+}
+
+class ErrorResponse(@XmlElement var code: Int, @XmlElement var message: String) {
+  def this() = this(0, null)
+
+  @XmlTransient
+  def getCode: Int = code
+
+  def setCode(code: Int) = this.code = code
+
+  def getType: String = code match {
+    case ErrorResponse.ERROR => "error"
+    case ErrorResponse.WARNING => "warning"
+    case ErrorResponse.INFO => "info"
+    case ErrorResponse.OK => "ok"
+    case ErrorResponse.TOO_BUSY => "too busy"
+    case _ => "unknown"
+  }
+
+  def setType(`type`: String) = {}
+
+  def getMessage: String = message
+
+  def setMessage(message: String) = this.message = message
+}
+
+class ApiHelpController extends SwaggerBaseApiController {
+
+  def getResources = Action {
+    request =>
+      implicit val requestHeader: RequestHeader = request
+      val host = requestHeader.host
+      val resourceListing = getResourceListing(host)
+      val responseStr = returnXml(request) match {
+        case true => toXmlString(resourceListing)
+        case false => toJsonString(resourceListing)
+      }
+      returnValue(request, responseStr)
+  }
+
+  def getResource(path: String) = Action {
+    request =>
+      implicit val requestHeader: RequestHeader = request
+      val host = requestHeader.host
+      val apiListing = getApiListing(path, host)
+      val responseStr = returnXml(request) match {
+        case true => toXmlString(apiListing)
+        case false => toJsonString(apiListing)
+      }
+      Option(responseStr) match {
+        case Some(help) => returnValue(request, help)
+        case None =>
+          val msg = new ErrorResponse(500, "api listing for path " + path + " not found")
+          Logger("swagger").error(msg.message)
+          if (returnXml(request)) {
+            InternalServerError.chunked(Enumerator(toXmlString(msg).getBytes("UTF-8"))).as("application/xml")
+          } else {
+            InternalServerError.chunked(Enumerator(toJsonString(msg).getBytes("UTF-8"))).as("application/json")
+          }
+      }
+  }
+}
+
+class SwaggerBaseApiController extends Controller {
+
+  protected def returnXml(request: Request[_]) = request.path.contains(".xml")
+
+  protected val AccessControlAllowOrigin = ("Access-Control-Allow-Origin", "*")
+
+  /**
+   * Get a list of all top level resources
+   */
+  protected def getResourceListing(host: String)(implicit requestHeader: RequestHeader) = {
+    Logger("swagger").debug("ApiHelpInventory.getRootResources")
+    val docRoot = ""
+    val queryParams = (for((key, value) <- requestHeader.queryString) yield {
+      (key, value.toList.asJava)
+    }).toMap
+    val cookies = (for(cookie <- requestHeader.cookies) yield {
+      (cookie.name, cookie.value)
+    }).toMap
+    val headers = (for((key, value) <- requestHeader.headers.toMap) yield {
+      (key, value.toList.asJava)
+    }).toMap
+
+    val f = new SpecFilter
+    val l: Option[Swagger] = ApiListingCache.listing(docRoot, host)
+
+    val specs: Swagger = l match {
+      case Some(m) => m
+      case _ => new Swagger()
+    }
+
+    val hasFilter = Option(FilterFactory.getFilter)
+    hasFilter match {
+      case Some(filter) => f.filter(specs, FilterFactory.getFilter, queryParams.asJava, cookies, headers)
+      case None => specs
+    }
+
+
+  }
+
+  /**
+   * Get detailed API/models for a given resource
+   */
+  protected def getApiListing(resourceName: String, host: String)(implicit requestHeader: RequestHeader) = {
+    Logger("swagger").debug("ApiHelpInventory.getResource(%s)".format(resourceName))
+    val docRoot = ""
+    val f = new SpecFilter
+    val queryParams = requestHeader.queryString.map {case (key, value) => key -> value.toList.asJava}
+    val cookies = requestHeader.cookies.map {cookie => cookie.name -> cookie.value}.toMap.asJava
+    val headers = requestHeader.headers.toMap.map {case (key, value) => key -> value.toList.asJava}
+    val pathPart = resourceName
+
+    val l: Option[Swagger] = ApiListingCache.listing(docRoot, host)
+    val specs: Swagger = l match {
+      case Some(m) => m
+      case _ => new Swagger()
+    }
+    val hasFilter = Option(FilterFactory.getFilter)
+
+    val clone = hasFilter match {
+      case Some(filter) => f.filter(specs, FilterFactory.getFilter, queryParams.asJava, cookies, headers)
+      case None => specs
+    }
+    clone.setPaths(clone.getPaths.filterKeys(_.startsWith(pathPart) ))
+    clone
+  }
+
+  def toXmlString(data: Any): String = {
+    if (data.getClass.equals(classOf[String])) {
+      data.asInstanceOf[String]
+    } else {
+      val stringWriter = new StringWriter()
+      stringWriter.toString
+    }
+  }
+
+  protected def XmlResponse(data: Any) = {
+    val xmlValue = toXmlString(data)
+    Ok.chunked(Enumerator(xmlValue.getBytes("UTF-8"))).as("application/xml")
+  }
+
+  protected def returnValue(request: Request[_], obj: Any): Result = {
+    val response = returnXml(request) match {
+      case true => XmlResponse(obj)
+      case false => JsonResponse(obj)
+    }
+    response.withHeaders(AccessControlAllowOrigin)
+  }
+
+  def toJsonString(data: Any): String = {
+    if (data.getClass.equals(classOf[String])) {
+      data.asInstanceOf[String]
+    } else {
+      Json.pretty(data.asInstanceOf[AnyRef])
+    }
+  }
+
+  protected def JsonResponse(data: Any) = {
+    val jsonValue = toJsonString(data)
+    val jsonBytes = jsonValue.getBytes("UTF-8")
+    Result (
+      header = ResponseHeader(200, Map(CONTENT_LENGTH -> jsonBytes.length.toString)),
+      body = Enumerator(jsonBytes)
+    ).as ("application/json")
+  }
+}

--- a/play-2.5/swagger-play2/app/play/modules/swagger/ApiListingCache.scala
+++ b/play-2.5/swagger-play2/app/play/modules/swagger/ApiListingCache.scala
@@ -1,0 +1,33 @@
+package play.modules.swagger
+
+import io.swagger.config._
+import io.swagger.models.Swagger
+import play.api.Logger
+
+object ApiListingCache {
+  var cache: Option[Swagger] = None
+
+  def listing(docRoot: String, host: String): Option[Swagger] = {
+    cache.orElse {
+      Logger("swagger").debug("Loading API metadata")
+
+      val scanner = ScannerFactory.getScanner()
+      val classes = scanner.classes()
+      val reader = new PlayReader(null)
+      var swagger = reader.read(classes)
+
+      scanner match {
+        case config: SwaggerConfig => {
+          swagger = config.configure(swagger)
+        }
+        case config => {
+          // no config, do nothing
+        }
+      }
+      cache = Some(swagger)
+      cache
+    }
+    cache.get.setHost(host)
+    cache
+  }
+}

--- a/play-2.5/swagger-play2/app/play/modules/swagger/PlayApiScanner.scala
+++ b/play-2.5/swagger-play2/app/play/modules/swagger/PlayApiScanner.scala
@@ -1,0 +1,107 @@
+package play.modules.swagger
+
+import io.swagger.annotations.Api
+import io.swagger.config._
+import io.swagger.models.{Contact, Info, License, Scheme, Swagger}
+import org.apache.commons.lang3.StringUtils
+import play.api.Logger
+import play.modules.swagger.util.SwaggerContext
+
+import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
+
+/**
+  * Identifies Play Controllers annotated as Swagger API's.
+  * Uses the Play Router to identify Controllers, and then tests each for the API annotation.
+  */
+class PlayApiScanner() extends Scanner with SwaggerConfig {
+
+
+  private def updateInfoFromConfig(swagger: Swagger): Swagger = {
+
+    var info = new Info()
+    val playSwaggerConfig = PlayConfigFactory.getConfig
+
+    if (StringUtils.isNotBlank(playSwaggerConfig.description)) {
+      info.description(playSwaggerConfig.description);
+    }
+
+    if (StringUtils.isNotBlank(playSwaggerConfig.title)) {
+      info.title(playSwaggerConfig.title);
+    } else {
+      // title tag needs to be present to validate against schema
+      info.title("");
+    }
+
+    if (StringUtils.isNotBlank(playSwaggerConfig.version)) {
+      info.version(playSwaggerConfig.version);
+    }
+
+    if (StringUtils.isNotBlank(playSwaggerConfig.termsOfServiceUrl)) {
+      info.termsOfService(playSwaggerConfig.termsOfServiceUrl);
+    }
+
+    if (playSwaggerConfig.contact != null) {
+      info.contact(new Contact()
+        .name(playSwaggerConfig.contact));
+    }
+    if (playSwaggerConfig.license != null && playSwaggerConfig.licenseUrl != null) {
+      info.license(new License()
+        .name(playSwaggerConfig.license)
+        .url(playSwaggerConfig.licenseUrl));
+    }
+    swagger.info(info)
+  }
+
+  override def configure(swagger: Swagger): Swagger = {
+    val playSwaggerConfig = PlayConfigFactory.getConfig
+    if (playSwaggerConfig.schemes != null) {
+      for (s <- playSwaggerConfig.schemes) swagger.scheme(Scheme.forValue(s))
+    }
+    updateInfoFromConfig(swagger)
+    swagger.host(playSwaggerConfig.host)
+    swagger.basePath(playSwaggerConfig.basePath);
+
+  }
+
+  override def getFilterClass(): String = {
+    null
+  }
+
+  override def classes(): java.util.Set[Class[_]] = {
+    Logger("swagger").info("ControllerScanner - looking for controllers with API annotation")
+
+
+    var routes = RouteFactory.getRoute().getAll().toList
+
+    // get controller names from application routes
+    val controllers = routes.map { case (_, route) =>
+      s"${route.call.packageName}.${route.call.controller}"
+    }.distinct
+
+
+    var list = controllers.collect {
+      case className: String if {
+        try {
+          SwaggerContext.loadClass(className).getAnnotation(classOf[Api]) != null
+        } catch {
+          case ex: Exception => {
+            Logger("swagger").error("Problem loading class:  %s. %s: %s".format(className, ex.getClass.getName, ex.getMessage))
+            false
+          }
+        }
+      } =>
+        Logger("swagger").info("Found API controller:  %s".format(className))
+        SwaggerContext.loadClass(className)
+    }
+
+    list.toSet.asJava
+
+  }
+
+  override def getPrettyPrint(): Boolean = {
+    true;
+  }
+
+  override def setPrettyPrint(x: Boolean) {}
+}

--- a/play-2.5/swagger-play2/app/play/modules/swagger/PlayConfigFactory.java
+++ b/play-2.5/swagger-play2/app/play/modules/swagger/PlayConfigFactory.java
@@ -1,0 +1,15 @@
+package play.modules.swagger;
+
+
+public class PlayConfigFactory {
+
+    private static PlaySwaggerConfig instance;
+
+    public static void setConfig(PlaySwaggerConfig routes) {
+        instance = routes;
+    }
+
+    public static PlaySwaggerConfig getConfig() {
+        return instance;
+    }
+}

--- a/play-2.5/swagger-play2/app/play/modules/swagger/PlayReader.java
+++ b/play-2.5/swagger-play2/app/play/modules/swagger/PlayReader.java
@@ -1,0 +1,859 @@
+package play.modules.swagger;
+
+import com.fasterxml.jackson.databind.JavaType;
+import io.swagger.annotations.*;
+import io.swagger.annotations.Info;
+import io.swagger.converter.ModelConverters;
+import io.swagger.models.*;
+import io.swagger.models.Contact;
+import io.swagger.models.ExternalDocs;
+import io.swagger.models.Tag;
+import io.swagger.models.parameters.*;
+import io.swagger.models.parameters.Parameter;
+import io.swagger.models.properties.*;
+import io.swagger.util.BaseReaderUtils;
+import io.swagger.util.Json;
+import io.swagger.util.ParameterProcessor;
+import io.swagger.util.PrimitiveType;
+import io.swagger.util.ReflectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import play.Logger;
+import play.modules.swagger.util.CrossUtil;
+import play.routes.compiler.*;
+import scala.Option;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class PlayReader {
+
+    private static final String SUCCESSFUL_OPERATION = "successful operation";
+
+    private Swagger swagger;
+
+    public Swagger getSwagger() {
+        return swagger;
+    }
+
+    public PlayReader(Swagger swagger) {
+        this.swagger = swagger == null ? new Swagger() : swagger;
+    }
+
+    public Swagger read(Set<Class<?>> classes) {
+
+        // process SwaggerDefinitions first - so we get tags in desired order
+        for (Class<?> cls : classes) {
+            SwaggerDefinition swaggerDefinition = cls.getAnnotation(SwaggerDefinition.class);
+            if (swaggerDefinition != null) {
+                readSwaggerConfig(cls, swaggerDefinition);
+            }
+        }
+
+        for (Class<?> cls : classes) {
+            read(cls);
+        }
+        return swagger;
+    }
+
+    public Swagger read(Class<?> cls) {
+        return read(cls, false);
+    }
+
+    private Swagger read(Class<?> cls, boolean readHidden) {
+
+        RouteWrapper routes = RouteFactory.getRoute();
+
+        PlaySwaggerConfig config = PlayConfigFactory.getConfig();
+
+        Api api = cls.getAnnotation(Api.class);
+
+        Map<String, Tag> tags = new HashMap<>();
+        List<SecurityRequirement> securities = new ArrayList<>();
+        String[] consumes = new String[0];
+        String[] produces = new String[0];
+        final Set<Scheme> globalSchemes = EnumSet.noneOf(Scheme.class);
+
+        final boolean readable = (api != null && readHidden) || (api != null && !api.hidden());
+
+        // TODO possibly allow parsing also without @Api annotation
+        if (readable) {
+            // the value will be used as a tag for 2.0 UNLESS a Tags annotation is present
+            Set<String> tagStrings = extractTags(api);
+            for (String tagString : tagStrings) {
+                Tag tag = new Tag().name(tagString);
+                tags.put(tagString, tag);
+            }
+            for (String tagName : tags.keySet()) {
+                getSwagger().tag(tags.get(tagName));
+            }
+
+            if (!api.produces().isEmpty()) {
+                produces = toArray(api.produces());
+            }
+            if (!api.consumes().isEmpty()) {
+                consumes =  toArray(api.consumes());
+            }
+            globalSchemes.addAll(parseSchemes(api.protocols()));
+            Authorization[] authorizations = api.authorizations();
+
+            for (Authorization auth : authorizations) {
+                if (auth.value() != null && !"".equals(auth.value())) {
+                    SecurityRequirement security = new SecurityRequirement();
+                    security.setName(auth.value());
+                    AuthorizationScope[] scopes = auth.scopes();
+                    for (AuthorizationScope scope : scopes) {
+                        if (scope.scope() != null && !"".equals(scope.scope())) {
+                            security.addScope(scope.scope());
+                        }
+                    }
+                    securities.add(security);
+                }
+            }
+
+            // parse the method
+            Method methods[] = cls.getMethods();
+            for (Method method : methods) {
+                if (ReflectionUtils.isOverriddenMethod(method, cls)) {
+                    continue;
+                }
+                // complete name as stored in route
+                String fullMethodName = getFullMethodName(cls, method);
+
+                if (!routes.exists(fullMethodName)) {
+                    continue;
+                }
+                Route route = routes.get(fullMethodName);
+
+                String operationPath = getPathFromRoute(route.path(), config.basePath);
+
+                if (operationPath != null) {
+                    final ApiOperation apiOperation = ReflectionUtils.getAnnotation(method, ApiOperation.class);
+
+                    String httpMethod = extractOperationMethod(apiOperation, method, route);
+                    Operation operation = null;
+                    if (apiOperation != null || httpMethod != null) {
+                        operation = parseMethod(cls, method, route);
+                    }
+
+                    if (operation == null) {
+                        continue;
+                    }
+
+                    if (apiOperation != null) {
+                        for (Scheme scheme : parseSchemes(apiOperation.protocols())) {
+                            operation.scheme(scheme);
+                        }
+                    }
+
+                    if (operation.getSchemes() == null || operation.getSchemes().isEmpty()) {
+                        for (Scheme scheme : globalSchemes) {
+                            operation.scheme(scheme);
+                        }
+                    }
+                    // can't continue without a valid http method
+                    if (httpMethod != null) {
+                        if (apiOperation != null) {
+                            for (String tag : apiOperation.tags()) {
+                                if (!"".equals(tag)) {
+                                    operation.tag(tag);
+                                    getSwagger().tag(new Tag().name(tag));
+                                }
+                            }
+
+                            operation.getVendorExtensions().putAll(BaseReaderUtils.parseExtensions(apiOperation.extensions()));
+                        }
+                        if (operation.getConsumes() == null) {
+                            for (String mediaType : consumes) {
+                                operation.consumes(mediaType);
+                            }
+                        }
+                        if (operation.getProduces() == null) {
+                            for (String mediaType : produces) {
+                                operation.produces(mediaType);
+                            }
+                        }
+
+                        if (operation.getTags() == null) {
+                            for (String tagString : tags.keySet()) {
+                                operation.tag(tagString);
+                            }
+                        }
+                        // Only add global @Api securities if operation doesn't already have more specific securities
+                        if (operation.getSecurity() == null) {
+                            for (SecurityRequirement security : securities) {
+                                operation.security(security);
+                            }
+                        }
+                        Path path = getSwagger().getPath(operationPath);
+                        if (path == null) {
+                            path = new Path();
+                            getSwagger().path(operationPath, path);
+                        }
+                        path.set(httpMethod, operation);
+                        try {
+                            readImplicitParameters(method, operation, cls);
+                        } catch (Exception e) {
+                            throw e;
+                        }
+                    }
+                }
+            }
+        }
+
+        return getSwagger();
+    }
+
+    String getPathFromRoute(PathPattern pathPattern, String basePath) {
+
+        StringBuilder sb = new StringBuilder();
+        scala.collection.Iterator iter = pathPattern.parts().iterator();
+        while (iter.hasNext()) {
+            PathPart part = (PathPart) iter.next();
+            if (part instanceof StaticPart) {
+                sb.append(((StaticPart) part).value());
+            } else if (part instanceof DynamicPart) {
+                sb.append("{");
+                sb.append(((DynamicPart) part).name());
+                sb.append("}");
+            } else {
+                try {
+                    sb.append(((StaticPart) part).value());
+                } catch (ClassCastException e) {
+                    Logger.warn(String.format("ClassCastException parsing path from route: %s", e.getMessage()));
+                }
+            }
+        }
+        StringBuilder operationPath = new StringBuilder();
+        if (basePath.startsWith("/")) basePath = basePath.substring(1);
+        operationPath.append(sb.toString().replaceFirst(basePath, ""));
+        if (!operationPath.toString().startsWith("/")) operationPath.insert(0, "/");
+        return operationPath.toString();
+    }
+
+    protected void readSwaggerConfig(Class<?> cls, SwaggerDefinition config) {
+
+        if (!config.basePath().isEmpty()) {
+            swagger.setBasePath(config.basePath());
+        }
+
+        if (!config.host().isEmpty()) {
+            swagger.setHost(config.host());
+        }
+
+        readInfoConfig(config);
+
+        for (String consume : config.consumes()) {
+            if (StringUtils.isNotEmpty(consume)) {
+                swagger.addConsumes(consume);
+            }
+        }
+
+        for (String produce : config.produces()) {
+            if (StringUtils.isNotEmpty(produce)) {
+                swagger.addProduces(produce);
+            }
+        }
+
+        if (!config.externalDocs().value().isEmpty()) {
+            ExternalDocs externalDocs = swagger.getExternalDocs();
+            if (externalDocs == null) {
+                externalDocs = new ExternalDocs();
+                swagger.setExternalDocs(externalDocs);
+            }
+
+            externalDocs.setDescription(config.externalDocs().value());
+
+            if (!config.externalDocs().url().isEmpty()) {
+                externalDocs.setUrl(config.externalDocs().url());
+            }
+        }
+
+        for (io.swagger.annotations.Tag tagConfig : config.tags()) {
+            if (!tagConfig.name().isEmpty()) {
+                Tag tag = new Tag();
+                tag.setName(tagConfig.name());
+                tag.setDescription(tagConfig.description());
+
+                if (!tagConfig.externalDocs().value().isEmpty()) {
+                    tag.setExternalDocs(new ExternalDocs(tagConfig.externalDocs().value(),
+                            tagConfig.externalDocs().url()));
+                }
+
+                tag.getVendorExtensions().putAll(BaseReaderUtils.parseExtensions(tagConfig.extensions()));
+
+                swagger.addTag(tag);
+            }
+        }
+
+        for (SwaggerDefinition.Scheme scheme : config.schemes()) {
+            if (scheme != SwaggerDefinition.Scheme.DEFAULT) {
+                swagger.addScheme(Scheme.forValue(scheme.name()));
+            }
+        }
+    }
+
+    protected void readInfoConfig(SwaggerDefinition config) {
+        Info infoConfig = config.info();
+        io.swagger.models.Info info = swagger.getInfo();
+        if (info == null) {
+            info = new io.swagger.models.Info();
+            swagger.setInfo(info);
+        }
+
+        if (!infoConfig.description().isEmpty()) {
+            info.setDescription(infoConfig.description());
+        }
+
+        if (!infoConfig.termsOfService().isEmpty()) {
+            info.setTermsOfService(infoConfig.termsOfService());
+        }
+
+        if (!infoConfig.title().isEmpty()) {
+            info.setTitle(infoConfig.title());
+        }
+
+        if (!infoConfig.version().isEmpty()) {
+            info.setVersion(infoConfig.version());
+        }
+
+        if (!infoConfig.contact().name().isEmpty()) {
+            Contact contact = info.getContact();
+            if (contact == null) {
+                contact = new Contact();
+                info.setContact(contact);
+            }
+
+            contact.setName(infoConfig.contact().name());
+            if (!infoConfig.contact().email().isEmpty()) {
+                contact.setEmail(infoConfig.contact().email());
+            }
+
+            if (!infoConfig.contact().url().isEmpty()) {
+                contact.setUrl(infoConfig.contact().url());
+            }
+        }
+
+        if (!infoConfig.license().name().isEmpty()) {
+            io.swagger.models.License license = info.getLicense();
+            if (license == null) {
+                license = new io.swagger.models.License();
+                info.setLicense(license);
+            }
+
+            license.setName(infoConfig.license().name());
+            if (!infoConfig.license().url().isEmpty()) {
+                license.setUrl(infoConfig.license().url());
+            }
+        }
+
+        info.getVendorExtensions().putAll(BaseReaderUtils.parseExtensions(infoConfig.extensions()));
+    }
+
+    private void readImplicitParameters(Method method, Operation operation, Class<?> cls) {
+        ApiImplicitParams implicitParams = method.getAnnotation(ApiImplicitParams.class);
+        if (implicitParams != null && implicitParams.value().length > 0) {
+            for (ApiImplicitParam param : implicitParams.value()) {
+                Parameter p = readImplicitParam(param, cls);
+                if (p != null) {
+                    operation.addParameter(p);
+                }
+            }
+        }
+    }
+
+    protected io.swagger.models.parameters.Parameter readImplicitParam(ApiImplicitParam param, Class<?> cls) {
+        final Parameter p;
+        if (param.paramType().equalsIgnoreCase("path")) {
+            p = new PathParameter();
+        } else if (param.paramType().equalsIgnoreCase("query")) {
+            p = new QueryParameter();
+        } else if (param.paramType().equalsIgnoreCase("form") || param.paramType().equalsIgnoreCase("formData")) {
+            p = new FormParameter();
+        } else if (param.paramType().equalsIgnoreCase("body")) {
+            p = null;
+        } else if (param.paramType().equalsIgnoreCase("header")) {
+            p = new HeaderParameter();
+        } else {
+            Logger.warn("Unkown implicit parameter type: [" + param.paramType() + "]");
+            return null;
+        }
+        Type type = null;
+        // Swagger ReflectionUtils can't handle file or array datatype
+        if (!"".equalsIgnoreCase(param.dataType()) && !"file".equalsIgnoreCase(param.dataType()) && !"array".equalsIgnoreCase(param.dataType())){
+            type = typeFromString(param.dataType(), cls);
+
+        }
+        Parameter result =  ParameterProcessor.applyAnnotations(getSwagger(), p, type == null ? String.class : type, Collections.singletonList(param));
+
+        if (result instanceof AbstractSerializableParameter && type != null) {
+            Property schema = createProperty(type);
+            ((AbstractSerializableParameter)p).setProperty(schema);
+        }
+
+        return result;
+
+    }
+
+    private static Type typeFromString(String type, Class<?> cls) {
+        final PrimitiveType primitive = PrimitiveType.fromName(type);
+        if (primitive != null) {
+            return primitive.getKeyClass();
+        }
+        try {
+            Type routeType = getOptionTypeFromString (type, cls);
+
+            if (routeType != null) return routeType;
+
+            return Thread.currentThread().getContextClassLoader().loadClass(type);
+        } catch (Exception e) {
+            Logger.error(String.format("Failed to resolve '%s' into class", type), e);
+        }
+        return null;
+    }
+
+    private Operation parseMethod(Class<?> cls, Method method, Route route) {
+        Operation operation = new Operation();
+
+        ApiOperation apiOperation = ReflectionUtils.getAnnotation(method, ApiOperation.class);
+        ApiResponses responseAnnotation = ReflectionUtils.getAnnotation(method, ApiResponses.class);
+
+        String operationId = method.getName();
+        operation.operationId(operationId);
+        String responseContainer = null;
+
+        Type responseType = null;
+        Map<String, Property> defaultResponseHeaders = new HashMap<>();
+
+        if (apiOperation != null) {
+            if (apiOperation.hidden()) {
+                return null;
+            }
+            if (!"".equals(apiOperation.nickname())) {
+                operationId = apiOperation.nickname();
+            }
+
+            defaultResponseHeaders = parseResponseHeaders(apiOperation.responseHeaders());
+
+            operation
+                    .summary(apiOperation.value())
+                    .description(apiOperation.notes());
+
+            if (apiOperation.response() != null && !isVoid(apiOperation.response())) {
+                responseType = apiOperation.response();
+            }
+            if (!"".equals(apiOperation.responseContainer())) {
+                responseContainer = apiOperation.responseContainer();
+            }
+            if (apiOperation.authorizations() != null) {
+                List<SecurityRequirement> securities = new ArrayList<>();
+                for (Authorization auth : apiOperation.authorizations()) {
+                    if (auth.value() != null && !"".equals(auth.value())) {
+                        SecurityRequirement security = new SecurityRequirement();
+                        security.setName(auth.value());
+                        AuthorizationScope[] scopes = auth.scopes();
+                        for (AuthorizationScope scope : scopes) {
+                            if (scope.scope() != null && !"".equals(scope.scope())) {
+                                security.addScope(scope.scope());
+                            }
+                        }
+                        securities.add(security);
+                    }
+                }
+                if (securities.size() > 0) {
+                    securities.forEach(operation::security);
+                }
+            }
+            if (apiOperation.consumes() != null && !apiOperation.consumes().isEmpty()) {
+                operation.consumes(Arrays.asList(toArray(apiOperation.consumes())));
+            }
+            if (apiOperation.produces() != null && !apiOperation.produces().isEmpty()) {
+                operation.produces(Arrays.asList(toArray(apiOperation.produces())));
+            }
+        }
+
+        if (apiOperation != null && StringUtils.isNotEmpty(apiOperation.responseReference())) {
+            Response response = new Response().description(SUCCESSFUL_OPERATION);
+            response.schema(new RefProperty(apiOperation.responseReference()));
+            operation.addResponse(String.valueOf(apiOperation.code()), response);
+        } else if (responseType == null) {
+            // pick out response from method declaration
+            responseType = method.getGenericReturnType();
+        }
+        if (isValidResponse(responseType)) {
+            final Property property = ModelConverters.getInstance().readAsProperty(responseType);
+            if (property != null) {
+                final Property responseProperty = ContainerWrapper.wrapContainer(responseContainer, property);
+                final int responseCode = apiOperation == null ? 200 : apiOperation.code();
+                operation.response(responseCode, new Response().description(SUCCESSFUL_OPERATION).schema(responseProperty)
+                        .headers(defaultResponseHeaders));
+                appendModels(responseType);
+            }
+        }
+
+        operation.operationId(operationId);
+
+        if (responseAnnotation != null) {
+            for (ApiResponse apiResponse : responseAnnotation.value()) {
+                Map<String, Property> responseHeaders = parseResponseHeaders(apiResponse.responseHeaders());
+
+                Response response = new Response()
+                        .description(apiResponse.message())
+                        .headers(responseHeaders);
+
+                if (apiResponse.code() == 0) {
+                    operation.defaultResponse(response);
+                } else {
+                    operation.response(apiResponse.code(), response);
+                }
+
+                if (StringUtils.isNotEmpty(apiResponse.reference())) {
+                    response.schema(new RefProperty(apiResponse.reference()));
+                } else if (!isVoid(apiResponse.response())) {
+                    responseType = apiResponse.response();
+                    final Property property = ModelConverters.getInstance().readAsProperty(responseType);
+                    if (property != null) {
+                        response.schema(ContainerWrapper.wrapContainer(apiResponse.responseContainer(), property));
+                        appendModels(responseType);
+                    }
+                }
+            }
+        }
+        if (ReflectionUtils.getAnnotation(method, Deprecated.class) != null) {
+            operation.setDeprecated(true);
+        }
+
+
+        List<Parameter> parameters = getParameters(cls, method, route);
+
+        parameters.forEach(operation::parameter);
+
+        if (operation.getResponses() == null) {
+            Response response = new Response().description(SUCCESSFUL_OPERATION);
+            operation.defaultResponse(response);
+        }
+        return operation;
+    }
+
+
+    final static class OptionTypeResolver {
+        private Option<Integer> optionTypeInt;
+        private Option<Long> optionTypeLong;
+        private Option<Byte> optionTypeByte;
+        private Option<Boolean> optionTypeBoolean;
+        private Option<Character> optionTypeChar;
+        private Option<Float> optionTypeFloat;
+        private Option<Double> optionTypeDouble;
+        private Option<Short> optionTypeShort;
+
+        static Type resolveOptionType (String innerType, Class<?> cls) {
+            try {
+                return Json.mapper().getTypeFactory().constructType(
+                        OptionTypeResolver.class.getDeclaredField("optionType" + innerType).getGenericType(), cls);
+            } catch (NoSuchFieldException e) {
+                return null;
+            }
+        }
+    }
+
+    private static Type getOptionTypeFromString (String simpleTypeName, Class<?> cls) {
+
+        if (simpleTypeName == null) return null;
+        String regex = "(Option|scala\\.Option)\\s*\\[\\s*(Int|Long|Float|Double|Byte|Short|Char|Boolean)\\s*\\]\\s*$";
+
+        Pattern pattern = Pattern.compile(regex);
+        Matcher matcher = pattern.matcher(simpleTypeName);
+        if (matcher.find())
+        {
+            String enhancedType = matcher.group(2);
+            return OptionTypeResolver.resolveOptionType(enhancedType, cls);
+        } else {
+            return null;
+        }
+    }
+
+    private Type getParamType(Class<?> cls, Method method, String simpleTypeName, int position) {
+
+        try {
+            Type type = getOptionTypeFromString (simpleTypeName, cls);
+            if (type != null) return type;
+
+            Type[] genericParameterTypes = method.getGenericParameterTypes();
+            return Json.mapper().getTypeFactory().constructType(genericParameterTypes[position], cls);
+        } catch (Exception e) {
+            Logger.error(String.format("Exception getting parameter type for method %s, param %s at position %d"), e);
+            return null;
+        }
+
+    }
+
+    private List<Annotation> getParamAnnotations(Class<?> cls, Type[] genericParameterTypes, Annotation[][] paramAnnotations, String simpleTypeName, int fieldPosition) {
+        try {
+            return Arrays.asList(paramAnnotations[fieldPosition]);
+        } catch (Exception e) {
+            Logger.error(String.format("Exception getting parameter type for method %s, param %s at position %d"), e);
+            return null;
+        }
+    }
+
+    private List<Annotation> getParamAnnotations(Class<?> cls, Method method, String simpleTypeName, int fieldPosition) {
+        Type[] genericParameterTypes = method.getGenericParameterTypes();
+        Annotation[][] paramAnnotations = method.getParameterAnnotations();
+        List<Annotation> annotations = getParamAnnotations(cls, genericParameterTypes, paramAnnotations, simpleTypeName, fieldPosition);
+        if (annotations != null) {
+            return annotations;
+        }
+
+        // Fallback to type
+        for (int i = 0; i < genericParameterTypes.length; i++) {
+            annotations = getParamAnnotations(cls, genericParameterTypes, paramAnnotations, simpleTypeName, i);
+            if (annotations != null) {
+                return annotations;
+            }
+        }
+        return null;
+    }
+
+    private List<Parameter> getParameters(Class<?> cls, Method method, Route route) {
+        // TODO now consider only parameters defined in route, excluding body parameters
+        // understand how to possibly infer body/form params e.g. from @BodyParser or other annotation
+
+        List<Parameter> parameters = new ArrayList<>();
+        if (!route.call().parameters().isDefined()) {
+            return parameters;
+        }
+        scala.collection.Iterator<play.routes.compiler.Parameter> iter  = route.call().parameters().get().iterator();
+
+        int fieldPosition = 0;
+        while (iter.hasNext()) {
+            play.routes.compiler.Parameter p = iter.next();
+            if (!p.fixed().isEmpty()) continue;
+            Parameter parameter;
+            String def = CrossUtil.getParameterDefaultField(p);
+            if (def.startsWith("\"") && def.endsWith("\"")){
+                def = def.substring(1,def.length()-1);
+            }
+            Type type = getParamType(cls, method, p.typeName(), fieldPosition);
+            Property schema = createProperty(type);
+            if (route.path().has(p.name())) {
+                // it's a path param
+                parameter = new PathParameter();
+                ((PathParameter)parameter).setDefaultValue(def);
+                if (schema != null) ((PathParameter)parameter).setProperty(schema);
+            } else {
+                // it's a query string param
+                parameter = new QueryParameter();
+                ((QueryParameter)parameter).setDefaultValue(def);
+                if (schema != null) ((QueryParameter)parameter).setProperty(schema);
+            }
+            parameter.setName(p.name());
+            List<Annotation> annotations = getParamAnnotations(cls, method, p.typeName(), fieldPosition);
+            ParameterProcessor.applyAnnotations(getSwagger(), parameter, type, annotations);
+            parameters.add(parameter);
+            fieldPosition++;
+        }
+        return parameters;
+    }
+
+    private static Set<Scheme> parseSchemes(String schemes) {
+        final Set<Scheme> result = EnumSet.noneOf(Scheme.class);
+        for (String item : StringUtils.trimToEmpty(schemes).split(",")) {
+            final Scheme scheme = Scheme.forValue(StringUtils.trimToNull(item));
+            if (scheme != null) {
+                result.add(scheme);
+            }
+        }
+        return result;
+    }
+
+    private static boolean isVoid(Type type) {
+        final Class<?> cls = Json.mapper().getTypeFactory().constructType(type).getRawClass();
+        return Void.class.isAssignableFrom(cls) || Void.TYPE.isAssignableFrom(cls);
+    }
+
+    private static boolean isValidResponse(Type type) {
+        if (type == null) {
+            return false;
+        }
+        final JavaType javaType = Json.mapper().getTypeFactory().constructType(type);
+        if (isVoid(javaType)) {
+            return false;
+        }
+        final Class<?> cls = javaType.getRawClass();
+        return !isResourceClass(cls);
+    }
+
+    private static boolean isResourceClass(Class<?> cls) {
+        return cls.getAnnotation(Api.class) != null;
+    }
+
+    protected Set<String> extractTags(Api api) {
+        Set<String> output = new LinkedHashSet<>();
+
+        boolean hasExplicitTags = false;
+        for (String tag : api.tags()) {
+            if (!"".equals(tag)) {
+                hasExplicitTags = true;
+                output.add(tag);
+            }
+        }
+        if (!hasExplicitTags) {
+            // derive tag from api path + description
+            String tagString = api.value().replace("/", "");
+            if (!"".equals(tagString)) {
+                output.add(tagString);
+            }
+        }
+        return output;
+    }
+
+    private Property createProperty(Type type) {
+        return enforcePrimitive(ModelConverters.getInstance().readAsProperty(type), 0);
+    }
+
+    private Property enforcePrimitive(Property in, int level) {
+        if (in instanceof RefProperty) {
+            return new StringProperty();
+        }
+        if (in instanceof ArrayProperty) {
+            if (level == 0) {
+                final ArrayProperty array = (ArrayProperty) in;
+                array.setItems(enforcePrimitive(array.getItems(), level + 1));
+            } else {
+                return new StringProperty();
+            }
+        }
+        return in;
+    }
+
+    private void appendModels(Type type) {
+        final Map<String, Model> models = ModelConverters.getInstance().readAll(type);
+        for (Map.Entry<String, Model> entry : models.entrySet()) {
+            getSwagger().model(entry.getKey(), entry.getValue());
+        }
+    }
+
+    private Map<String, Property> parseResponseHeaders(ResponseHeader[] headers) {
+        Map<String, Property> responseHeaders = null;
+        if (headers != null && headers.length > 0) {
+            for (ResponseHeader header : headers) {
+                String name = header.name();
+                if (!"".equals(name)) {
+                    if (responseHeaders == null) {
+                        responseHeaders = new HashMap<>();
+                    }
+                    String description = header.description();
+                    Class<?> cls = header.response();
+
+                    if (!isVoid(cls)) {
+                        final Property property = ModelConverters.getInstance().readAsProperty(cls);
+                        if (property != null) {
+                            Property responseProperty = ContainerWrapper.wrapContainer(header.responseContainer(), property,
+                                    ContainerWrapper.ARRAY, ContainerWrapper.LIST, ContainerWrapper.SET);
+                            responseProperty.setDescription(description);
+                            responseHeaders.put(name, responseProperty);
+                            appendModels(cls);
+                        }
+                    }
+                }
+            }
+        }
+        return responseHeaders;
+    }
+
+    public String getFullMethodName(Class clazz, Method method) {
+
+        if (!clazz.getCanonicalName().contains("$")) {
+            return clazz.getCanonicalName() + "$." + method.getName();
+        } else {
+            return clazz.getCanonicalName() + "." + method.getName();
+        }
+    }
+
+    public String extractOperationMethod(ApiOperation apiOperation,
+                                         Method method, Route route) {
+        String httpMethod = null;
+        if (route != null) {
+            try {
+                httpMethod = route.verb().toString().toLowerCase();
+            } catch (Exception e) {
+                Logger.error("http method not found for method: " + method.getName(), e);
+            }
+        }
+        if (httpMethod == null){
+            if (!StringUtils.isEmpty(apiOperation.httpMethod())) {
+                httpMethod = apiOperation.httpMethod();
+            }
+        }
+        return httpMethod;
+    }
+
+    private String[] toArray(String csString){
+        if (StringUtils.isEmpty(csString)) return new String[] {csString};
+        int i = 0;
+        String[] result = csString.split(",");
+        for (String c: result){
+            result[i] = c.trim();
+            i++;
+        }
+        return result;
+    }
+
+    enum ContainerWrapper {
+        LIST("list") {
+            @Override
+            protected Property doWrap(Property property) {
+                return new ArrayProperty(property);
+            }
+        },
+        ARRAY("array") {
+            @Override
+            protected Property doWrap(Property property) {
+                return new ArrayProperty(property);
+            }
+        },
+        MAP("map") {
+            @Override
+            protected Property doWrap(Property property) {
+                return new MapProperty(property);
+            }
+        },
+        SET("set") {
+            @Override
+            protected Property doWrap(Property property) {
+                ArrayProperty arrayProperty = new ArrayProperty(property);
+                arrayProperty.setUniqueItems(true);
+                return arrayProperty;
+            }
+        };
+
+        private final String container;
+
+        ContainerWrapper(String container) {
+            this.container = container;
+        }
+
+        public static Property wrapContainer(String container, Property property, ContainerWrapper... allowed) {
+            final Set<ContainerWrapper> tmp = allowed.length > 0 ? EnumSet.copyOf(Arrays.asList(allowed)) : EnumSet.allOf(ContainerWrapper.class);
+            for (ContainerWrapper wrapper : tmp) {
+                final Property prop = wrapper.wrap(container, property);
+                if (prop != null) {
+                    return prop;
+                }
+            }
+            return property;
+        }
+
+        public Property wrap(String container, Property property) {
+            if (this.container.equalsIgnoreCase(container)) {
+                return doWrap(property);
+            }
+            return null;
+        }
+
+        protected abstract Property doWrap(Property property);
+    }
+}

--- a/play-2.5/swagger-play2/app/play/modules/swagger/PlaySwaggerConfig.java
+++ b/play-2.5/swagger-play2/app/play/modules/swagger/PlaySwaggerConfig.java
@@ -1,0 +1,104 @@
+package play.modules.swagger;
+
+public class PlaySwaggerConfig {
+
+    String[] schemes;
+    String title;
+    String version;
+    String description;
+    String termsOfServiceUrl;
+    String contact;
+    String license;
+    String licenseUrl;
+    String filterClass;
+    String host;
+    String basePath;
+
+    public String[] getSchemes() {
+        return schemes;
+    }
+
+    public void setSchemes(String[] schemes) {
+        this.schemes = schemes;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getTermsOfServiceUrl() {
+        return termsOfServiceUrl;
+    }
+
+    public void setTermsOfServiceUrl(String termsOfServiceUrl) {
+        this.termsOfServiceUrl = termsOfServiceUrl;
+    }
+
+    public String getContact() {
+        return contact;
+    }
+
+    public void setContact(String contact) {
+        this.contact = contact;
+    }
+
+    public String getLicense() {
+        return license;
+    }
+
+    public void setLicense(String license) {
+        this.license = license;
+    }
+
+    public String getLicenseUrl() {
+        return licenseUrl;
+    }
+
+    public void setLicenseUrl(String licenseUrl) {
+        this.licenseUrl = licenseUrl;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public String getFilterClass() {
+        return filterClass;
+    }
+
+    public void setFilterClass(String filterClass) {
+        this.filterClass = filterClass;
+    }
+
+    public String getBasePath() {
+        return basePath;
+    }
+
+    public void setBasePath(String basePath) {
+        this.basePath = basePath;
+    }
+}

--- a/play-2.5/swagger-play2/app/play/modules/swagger/RouteFactory.java
+++ b/play-2.5/swagger-play2/app/play/modules/swagger/RouteFactory.java
@@ -1,0 +1,15 @@
+package play.modules.swagger;
+
+
+public class RouteFactory {
+
+    private static RouteWrapper instance;
+
+    public static RouteWrapper getRoute() {
+        return instance;
+    }
+
+    public static void setRoute(RouteWrapper routes) {
+        instance = routes;
+    }
+}

--- a/play-2.5/swagger-play2/app/play/modules/swagger/RouteWrapper.java
+++ b/play-2.5/swagger-play2/app/play/modules/swagger/RouteWrapper.java
@@ -1,0 +1,29 @@
+package play.modules.swagger;
+
+import play.routes.compiler.Route;
+
+import java.util.Map;
+
+
+public class RouteWrapper {
+
+    private Map<String, Route> router;
+
+    public RouteWrapper(Map<String, Route> router) {
+        this.router = router;
+    }
+
+    public Route get(String routeName) {
+        return router.get(routeName);
+    }
+
+    public boolean exists(String routeName) {
+        return router.containsKey(routeName);
+    }
+
+    public Map<String, Route> getAll() {
+        return router;
+    }
+
+
+}

--- a/play-2.5/swagger-play2/app/play/modules/swagger/SwaggerApplicationLoader.scala
+++ b/play-2.5/swagger-play2/app/play/modules/swagger/SwaggerApplicationLoader.scala
@@ -13,9 +13,9 @@ trait SwaggerApplicationLoader extends ApplicationLoader {
     val comp = components(context)
     val application = comp.application
     val life : ApplicationLifecycle = new ApplicationLifecycle() {
-      override def addStopHook(hook: () => Future[Unit]): Unit = ()
+      override def addStopHook(hook: () => Future[_]): Unit = ()
     }
-    new SwaggerPluginImpl(life, comp.router, application)
+    new SwaggerPluginImpl(life, application.configuration, comp.environment)
     application
   }
 }

--- a/play-2.5/swagger-play2/app/play/modules/swagger/SwaggerApplicationLoader.scala
+++ b/play-2.5/swagger-play2/app/play/modules/swagger/SwaggerApplicationLoader.scala
@@ -1,0 +1,21 @@
+package play.modules.swagger
+
+import play.api.ApplicationLoader.Context
+import play.api.inject.ApplicationLifecycle
+import play.api.{BuiltInComponents, ApplicationLoader}
+
+import scala.concurrent.Future
+
+trait SwaggerApplicationLoader extends ApplicationLoader {
+  def components(context: Context) : BuiltInComponents
+
+  def load(context: Context) = {
+    val comp = components(context)
+    val application = comp.application
+    val life : ApplicationLifecycle = new ApplicationLifecycle() {
+      override def addStopHook(hook: () => Future[Unit]): Unit = ()
+    }
+    new SwaggerPluginImpl(life, comp.router, application)
+    application
+  }
+}

--- a/play-2.5/swagger-play2/app/play/modules/swagger/SwaggerModule.scala
+++ b/play-2.5/swagger-play2/app/play/modules/swagger/SwaggerModule.scala
@@ -1,0 +1,15 @@
+package play.modules.swagger
+
+
+import controllers.ApiHelpController
+import play.api.inject.{Binding, Module}
+import play.api.{Configuration, Environment}
+
+class SwaggerModule extends Module {
+
+  override def bindings(environment: Environment, configuration: Configuration): Seq[Binding[_]] =  Seq(
+    bind[SwaggerPlugin].to[SwaggerPluginImpl].eagerly(),
+    bind[ApiHelpController].toSelf.eagerly()
+  )
+
+}

--- a/play-2.5/swagger-play2/app/play/modules/swagger/SwaggerPlugin.scala
+++ b/play-2.5/swagger-play2/app/play/modules/swagger/SwaggerPlugin.scala
@@ -1,0 +1,176 @@
+/**
+ * Copyright 2014 Reverb Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package play.modules.swagger
+
+import java.io.File
+import javax.inject.Inject
+import io.swagger.config.{FilterFactory, ScannerFactory}
+import play.modules.swagger.util.SwaggerContext
+import io.swagger.core.filter.SwaggerSpecFilter
+import play.api.inject.ApplicationLifecycle
+import play.api.{Logger, Application}
+import play.api.routing.Router
+import scala.concurrent.Future
+import scala.collection.JavaConversions._
+import play.routes.compiler.{Route => PlayRoute, Include => PlayInclude, RoutesFileParser, StaticPart}
+
+import scala.io.Source
+
+trait SwaggerPlugin
+
+class SwaggerPluginImpl @Inject()(lifecycle: ApplicationLifecycle, router: Router, app: Application) extends SwaggerPlugin {
+
+  val logger = Logger("swagger")
+
+  val config = app.configuration
+  logger.info("Swagger - starting initialisation...")
+
+  val apiVersion = config.getString("api.version") match {
+    case None => "beta"
+    case Some(value) => value
+  }
+
+  val basePath = config.getString("swagger.api.basepath")
+    .filter(path => !path.isEmpty)
+    .getOrElse("/")
+
+  val host = config.getString("swagger.api.host")
+    .filter(host => !host.isEmpty)
+    .getOrElse("localhost:9000")
+
+  val title = config.getString("swagger.api.info.title") match {
+    case None => ""
+    case Some(value)=> value
+  }
+
+  val description = config.getString("swagger.api.info.description") match {
+    case None => ""
+    case Some(value)=> value
+  }
+
+  val termsOfServiceUrl = config.getString("swagger.api.info.termsOfServiceUrl") match {
+    case None => ""
+    case Some(value)=> value
+  }
+
+  val contact = config.getString("swagger.api.info.contact") match {
+    case None => ""
+    case Some(value)=> value
+  }
+
+  val license = config.getString("swagger.api.info.license") match {
+    case None => ""
+    case Some(value)=> value
+  }
+
+  val licenseUrl = config.getString("swagger.api.info.licenseUrl") match {
+    // licenceUrl needs to be a valid URL to validate against schema
+    case None => "http://licenseUrl"
+    case Some(value)=> value
+  }
+
+  SwaggerContext.registerClassLoader(app.classloader)
+
+  var scanner = new PlayApiScanner()
+  ScannerFactory.setScanner(scanner)
+
+  var swaggerConfig = new PlaySwaggerConfig()
+
+  swaggerConfig.description = description
+  swaggerConfig.basePath = basePath
+  swaggerConfig.contact = contact
+  swaggerConfig.version = apiVersion
+  swaggerConfig.title = title
+  swaggerConfig.host = host
+  swaggerConfig.termsOfServiceUrl = termsOfServiceUrl
+  swaggerConfig.license = license
+  swaggerConfig.licenseUrl = licenseUrl
+
+  PlayConfigFactory.setConfig(swaggerConfig)
+
+
+  val routes = parseRoutes
+
+  def parseRoutes: List[PlayRoute] = {
+    def playRoutesClassNameToFileName(className: String) = className.replace(".Routes", ".routes")
+
+    val routesFile = config.underlying.hasPath("play.http.router") match {
+      case false => "routes"
+      case true => config.getString("play.http.router") match {
+        case None => "routes"
+        case Some(value)=> playRoutesClassNameToFileName(value)
+      }
+    }
+    //Parses multiple route files recursively
+    def parseRoutesHelper(routesFile: String, prefix: String): List[PlayRoute] = {
+      logger.debug(s"Processing route file '$routesFile' with prefix '$prefix'")
+
+      val routesContent =  Source.fromInputStream(app.classloader.getResourceAsStream(routesFile)).mkString
+      val parsedRoutes = RoutesFileParser.parseContent(routesContent,new File(routesFile))
+      val routes = parsedRoutes.right.get.collect {
+        case (route: PlayRoute) => {
+          logger.debug(s"Adding route '$route'")
+          Seq(route.copy(path = route.path.copy(parts = StaticPart(prefix + "/") +: route.path.parts)))
+        }
+        case (include: PlayInclude) => {
+          logger.debug(s"Processing route include $include")
+          parseRoutesHelper(playRoutesClassNameToFileName(include.router), include.prefix)
+        }
+      }.flatten
+      logger.debug(s"Finished processing route file '$routesFile'")
+      routes
+    }
+    parseRoutesHelper(routesFile, "")
+  }
+
+  val routesRules = Map(routes map
+    { route =>
+    {
+      val routeName = s"${route.call.packageName}.${route.call.controller}$$.${route.call.method}"
+      (routeName -> route)
+    }
+    } : _*)
+
+  val route = new RouteWrapper(routesRules)
+  RouteFactory.setRoute(route)
+  app.configuration.getString("swagger.filter") match {
+    case Some(e) if (e != "") => {
+      try {
+        FilterFactory setFilter SwaggerContext.loadClass(e).newInstance.asInstanceOf[SwaggerSpecFilter]
+        logger.debug("Setting swagger.filter to %s".format(e))
+      }
+      catch {
+        case ex: Exception => Logger("swagger").error("Failed to load filter " + e, ex)
+      }
+    }
+    case _ =>
+  }
+
+  val docRoot = ""
+  ApiListingCache.listing(docRoot, "127.0.0.1")
+
+  logger.info("Swagger - initialization done.")
+
+  // previous contents of Plugin.onStart
+  lifecycle.addStopHook { () =>
+    ApiListingCache.cache = None
+    logger.info("Swagger - stopped.")
+
+    Future.successful(())
+  }
+
+}

--- a/play-2.5/swagger-play2/app/play/modules/swagger/SwaggerPlugin.scala
+++ b/play-2.5/swagger-play2/app/play/modules/swagger/SwaggerPlugin.scala
@@ -18,25 +18,29 @@ package play.modules.swagger
 
 import java.io.File
 import javax.inject.Inject
+
 import io.swagger.config.{FilterFactory, ScannerFactory}
 import play.modules.swagger.util.SwaggerContext
 import io.swagger.core.filter.SwaggerSpecFilter
 import play.api.inject.ApplicationLifecycle
-import play.api.{Logger, Application}
+import play.api.{Application, Configuration, Environment, Logger}
 import play.api.routing.Router
+
 import scala.concurrent.Future
 import scala.collection.JavaConversions._
-import play.routes.compiler.{Route => PlayRoute, Include => PlayInclude, RoutesFileParser, StaticPart}
+import play.routes.compiler.{RoutesFileParser, StaticPart, Include => PlayInclude, Route => PlayRoute}
 
 import scala.io.Source
 
 trait SwaggerPlugin
 
-class SwaggerPluginImpl @Inject()(lifecycle: ApplicationLifecycle, router: Router, app: Application) extends SwaggerPlugin {
+class SwaggerPluginImpl @Inject()(lifecycle: ApplicationLifecycle,
+                                  configuration: Configuration,
+                                  environment: Environment) extends SwaggerPlugin {
 
   val logger = Logger("swagger")
-
-  val config = app.configuration
+  val config = configuration
+  val classloader = environment.classLoader
   logger.info("Swagger - starting initialisation...")
 
   val apiVersion = config.getString("api.version") match {
@@ -83,7 +87,7 @@ class SwaggerPluginImpl @Inject()(lifecycle: ApplicationLifecycle, router: Route
     case Some(value)=> value
   }
 
-  SwaggerContext.registerClassLoader(app.classloader)
+  SwaggerContext.registerClassLoader(classloader)
 
   var scanner = new PlayApiScanner()
   ScannerFactory.setScanner(scanner)
@@ -119,7 +123,7 @@ class SwaggerPluginImpl @Inject()(lifecycle: ApplicationLifecycle, router: Route
     def parseRoutesHelper(routesFile: String, prefix: String): List[PlayRoute] = {
       logger.debug(s"Processing route file '$routesFile' with prefix '$prefix'")
 
-      val routesContent =  Source.fromInputStream(app.classloader.getResourceAsStream(routesFile)).mkString
+      val routesContent =  Source.fromInputStream(classloader.getResourceAsStream(routesFile)).mkString
       val parsedRoutes = RoutesFileParser.parseContent(routesContent,new File(routesFile))
       val routes = parsedRoutes.right.get.collect {
         case (route: PlayRoute) => {
@@ -147,7 +151,7 @@ class SwaggerPluginImpl @Inject()(lifecycle: ApplicationLifecycle, router: Route
 
   val route = new RouteWrapper(routesRules)
   RouteFactory.setRoute(route)
-  app.configuration.getString("swagger.filter") match {
+  configuration.getString("swagger.filter") match {
     case Some(e) if (e != "") => {
       try {
         FilterFactory setFilter SwaggerContext.loadClass(e).newInstance.asInstanceOf[SwaggerSpecFilter]

--- a/play-2.5/swagger-play2/app/play/modules/swagger/util/CrossUtil.scala
+++ b/play-2.5/swagger-play2/app/play/modules/swagger/util/CrossUtil.scala
@@ -1,0 +1,9 @@
+package play.modules.swagger.util
+
+import play.routes.compiler.Parameter
+
+object CrossUtil {
+  def getParameterDefaultField(parameter: Parameter): String = {
+    parameter.default.getOrElse("")
+  }
+}

--- a/play-2.5/swagger-play2/app/play/modules/swagger/util/SwaggerContext.scala
+++ b/play-2.5/swagger-play2/app/play/modules/swagger/util/SwaggerContext.scala
@@ -1,0 +1,39 @@
+package play.modules.swagger.util
+
+import collection.mutable.ListBuffer
+import org.slf4j.{LoggerFactory, Logger}
+
+/**
+  * @author ayush
+  * @since 10/9/11 5:36 PM
+  *
+  */
+object SwaggerContext {
+  private val LOGGER = LoggerFactory.getLogger("play.modules.swagger.util.SwaggerContext")
+
+  var suffixResponseFormat = true
+
+  private val classLoaders = ListBuffer.empty[ClassLoader]
+  registerClassLoader(this.getClass.getClassLoader)
+
+  def registerClassLoader(cl: ClassLoader) = this.classLoaders += cl
+
+  def loadClass(name: String) = {
+    var clazz: Class[_] = null
+
+    for (classLoader <- classLoaders.reverse) {
+      if(clazz == null) {
+        try {
+          clazz = Class.forName(name, true, classLoader)
+        } catch {
+          case e: ClassNotFoundException => LOGGER.debug("Class not found in classLoader " + classLoader)
+        }
+      }
+    }
+
+    if(clazz == null)
+      throw new ClassNotFoundException("class " + name + " not found")
+
+    clazz
+  }
+}

--- a/play-2.5/swagger-play2/build.sbt
+++ b/play-2.5/swagger-play2/build.sbt
@@ -1,0 +1,71 @@
+name := "swagger-play2"
+version := "1.5.2-SNAPSHOT"
+
+checksums in update := Nil
+
+scalaVersion:= "2.11.6"
+crossScalaVersions := Seq("2.11.6", "2.11.7")
+
+libraryDependencies ++= Seq(
+  "org.slf4j"          % "slf4j-api"                  % "1.6.4",
+  "io.swagger"         % "swagger-core"               % "1.5.8",
+  "io.swagger"        %% "swagger-scala-module"       % "1.0.2-SNAPSHOT",
+  "com.typesafe.play" %% "routes-compiler"            % "2.4.6",
+  "com.typesafe.play" %% "play-ebean"                 % "2.0.0"            % "test",
+  "org.specs2"        %% "specs2-core"                % "3.6.6"            % "test",
+  "org.specs2"        %% "specs2-mock"                % "3.6.6"            % "test",
+  "org.specs2"        %% "specs2-junit"               % "3.6.6"            % "test",
+  "org.mockito"        % "mockito-core"               % "1.9.5"            % "test")
+
+mappings in (Compile, packageBin) ~= { _.filter(!_._1.getName.equals("logback.xml")) }
+
+publishTo <<= version { (v: String) =>
+  val nexus = "https://oss.sonatype.org/"
+  if (v.trim.endsWith("SNAPSHOT"))
+    Some("snapshots" at nexus + "content/repositories/snapshots")
+  else
+    Some("releases"  at nexus + "service/local/staging/deploy/maven2")
+}
+publishArtifact in Test := false
+publishMavenStyle := true
+pomIncludeRepository := { x => false }
+credentials += Credentials(Path.userHome / ".ivy2" / ".credentials")
+organization := "io.swagger"
+pomExtra := {
+  <url>http://swagger.io</url>
+  <licenses>
+    <license>
+      <name>Apache License 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+  <scm>
+    <url>git@github.com:swagger-api/swagger-play.git</url>
+    <connection>scm:git:git@github.com:swagger-api/swagger-play.git</connection>
+  </scm>
+  <developers>
+    <developer>
+      <id>fehguy</id>
+      <name>Tony Tam</name>
+      <email>fehguy@gmail.com</email>
+    </developer>
+    <developer>
+      <id>ayush</id>
+      <name>Ayush Gupta</name>
+      <email>ayush@glugbot.com</email>
+    </developer>
+    <developer>
+      <id>rayyildiz</id>
+      <name>Ramazan AYYILDIZ</name>
+      <email>rayyildiz@gmail.com</email>
+    </developer>
+    <developer>
+      <id>benmccann</id>
+      <name>Ben McCann</name>
+      <url>http://www.benmccann.com/</url>
+    </developer>
+  </developers>
+}
+
+lazy val root = (project in file(".")).enablePlugins(PlayScala)

--- a/play-2.5/swagger-play2/build.sbt
+++ b/play-2.5/swagger-play2/build.sbt
@@ -9,7 +9,7 @@ crossScalaVersions := Seq("2.11.6", "2.11.7")
 libraryDependencies ++= Seq(
   "org.slf4j"                      % "slf4j-api"                  % "1.7.16",
   "io.swagger"                     % "swagger-core"               % "1.5.8",
-  "io.swagger"                    %% "swagger-scala-module"       % "1.0.2-SNAPSHOT",
+  "io.swagger"                    %% "swagger-scala-module"       % "1.0.2",
   "com.typesafe.play"             %% "routes-compiler"            % "2.5.1",
   "com.fasterxml.jackson.module"  %% "jackson-module-scala"       % "2.7.2",
   "com.typesafe.play"             %% "play-ebean"                 % "3.0.0"            % "test",

--- a/play-2.5/swagger-play2/build.sbt
+++ b/play-2.5/swagger-play2/build.sbt
@@ -7,15 +7,16 @@ scalaVersion:= "2.11.6"
 crossScalaVersions := Seq("2.11.6", "2.11.7")
 
 libraryDependencies ++= Seq(
-  "org.slf4j"          % "slf4j-api"                  % "1.6.4",
-  "io.swagger"         % "swagger-core"               % "1.5.8",
-  "io.swagger"        %% "swagger-scala-module"       % "1.0.2-SNAPSHOT",
-  "com.typesafe.play" %% "routes-compiler"            % "2.4.6",
-  "com.typesafe.play" %% "play-ebean"                 % "2.0.0"            % "test",
-  "org.specs2"        %% "specs2-core"                % "3.6.6"            % "test",
-  "org.specs2"        %% "specs2-mock"                % "3.6.6"            % "test",
-  "org.specs2"        %% "specs2-junit"               % "3.6.6"            % "test",
-  "org.mockito"        % "mockito-core"               % "1.9.5"            % "test")
+  "org.slf4j"                      % "slf4j-api"                  % "1.7.16",
+  "io.swagger"                     % "swagger-core"               % "1.5.8",
+  "io.swagger"                    %% "swagger-scala-module"       % "1.0.2-SNAPSHOT",
+  "com.typesafe.play"             %% "routes-compiler"            % "2.5.1",
+  "com.fasterxml.jackson.module"  %% "jackson-module-scala"       % "2.7.2",
+  "com.typesafe.play"             %% "play-ebean"                 % "3.0.0"            % "test",
+  "org.specs2"                    %% "specs2-core"                % "3.6.6"            % "test",
+  "org.specs2"                    %% "specs2-mock"                % "3.6.6"            % "test",
+  "org.specs2"                    %% "specs2-junit"               % "3.6.6"            % "test",
+  "org.mockito"                    % "mockito-core"               % "1.10.19"          % "test")
 
 mappings in (Compile, packageBin) ~= { _.filter(!_._1.getName.equals("logback.xml")) }
 

--- a/play-2.5/swagger-play2/conf/logback.xml
+++ b/play-2.5/swagger-play2/conf/logback.xml
@@ -1,0 +1,23 @@
+<configuration>
+    
+  <conversionRule conversionWord="coloredLevel" converterClass="play.api.Logger$ColoredLevel" />
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%coloredLevel - %logger - %message%n%xException</pattern>
+    </encoder>
+  </appender>
+
+  <!--
+    The logger name is typically the Java/Scala package name.
+    This configures the log level to log at for a package and its children packages.
+  -->
+  <logger name="play" level="ERROR" />
+
+  <logger name="application" level="DEBUG" />
+
+  <root level="ERROR">
+    <appender-ref ref="STDOUT" />
+  </root>
+
+</configuration>

--- a/play-2.5/swagger-play2/project/build.properties
+++ b/play-2.5/swagger-play2/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.8

--- a/play-2.5/swagger-play2/project/plugins.sbt
+++ b/play-2.5/swagger-play2/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin"      % "2.4.6")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin"      % "2.5.1")
 
 addSbtPlugin("com.jsuereth"      % "sbt-pgp"         % "1.0.0")

--- a/play-2.5/swagger-play2/project/plugins.sbt
+++ b/play-2.5/swagger-play2/project/plugins.sbt
@@ -1,0 +1,3 @@
+addSbtPlugin("com.typesafe.play" % "sbt-plugin"      % "2.4.6")
+
+addSbtPlugin("com.jsuereth"      % "sbt-pgp"         % "1.0.0")

--- a/play-2.5/swagger-play2/test/EBeanModelTest.scala
+++ b/play-2.5/swagger-play2/test/EBeanModelTest.scala
@@ -1,0 +1,20 @@
+import testdata._
+
+import io.swagger.converter._
+
+import org.specs2.mutable._
+import org.specs2.mock.Mockito
+
+class EBeanModelTest extends Specification with Mockito {
+  "ModelConverters" should {
+    "not parse an EBean" in {
+      val models = ModelConverters.getInstance().readAll(classOf[Person])
+      models.size must beEqualTo(1)
+
+      val model = models.entrySet().iterator().next().getValue
+      val property = model.getProperties.keySet().iterator().next()
+
+      property must beEqualTo("name")
+    }
+  }
+}

--- a/play-2.5/swagger-play2/test/PlayApiListingCacheSpec.scala
+++ b/play-2.5/swagger-play2/test/PlayApiListingCacheSpec.scala
@@ -1,0 +1,207 @@
+import java.io.File
+
+import io.swagger.config.ScannerFactory
+import io.swagger.models.{ModelImpl, HttpMethod}
+import io.swagger.models.parameters.{QueryParameter, BodyParameter, PathParameter}
+import io.swagger.models.properties.{RefProperty, ArrayProperty}
+import play.modules.swagger._
+import org.specs2.mutable._
+import org.specs2.mock.Mockito
+import play.api.Logger
+import io.swagger.util.Json
+import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
+import play.routes.compiler.{ Route => PlayRoute }
+
+class PlayApiListingCacheSpec extends Specification with Mockito {
+
+  // set up mock for Play Router
+  val routesList = {
+    play.routes.compiler.RoutesFileParser.parseContent("""
+POST /api/document/:settlementId/files/:fileId/accept testdata.DocumentController.accept(settlementId:String,fileId:String)
+GET /api/search testdata.SettlementsSearcherController.search(personalNumber:String,propertyId:String)
+GET /api/pointsofinterest testdata.PointOfInterestController.list(eastingMin:Double,northingMin:Double,eastingMax:Double,northingMax:Double)
+GET /api/dog testdata.DogController.list
+PUT /api/dog testdata.DogController.add1
+GET /api/cat @testdata.CatController.list
+GET /api/cat43 @testdata.CatController.testIssue43(test_issue_43_param: Option[Int])
+PUT /api/cat @testdata.CatController.add1
+GET /api/fly testdata.FlyController.list
+PUT /api/dog testdata.DogController.add1
+PUT /api/dog/:id testdata.DogController.add0(id:String)
+    """, new File("")).right.get.collect {
+      case (route: PlayRoute) =>
+        val routeName = s"${route.call.packageName}.${route.call.controller}$$.${route.call.method}"
+        route
+    }
+  }
+
+  val routesRules = Map(routesList map 
+  { route =>
+    {
+      val routeName = s"${route.call.packageName}.${route.call.controller}$$.${route.call.method}"
+      routeName -> route
+    }
+  } : _*)
+
+  val apiVersion = "test1"
+  val basePath = "/api"
+
+  var swaggerConfig = new PlaySwaggerConfig()
+
+  swaggerConfig setDescription "description"
+  swaggerConfig setBasePath basePath
+  swaggerConfig setContact "contact"
+  swaggerConfig setHost "127.0.0.1"
+  swaggerConfig setVersion "beta"
+  swaggerConfig setTitle "title"
+  swaggerConfig setTermsOfServiceUrl "http://termsOfServiceUrl"
+  swaggerConfig setLicense "license"
+  swaggerConfig setLicenseUrl "http://licenseUrl"
+
+  PlayConfigFactory.setConfig(swaggerConfig)
+
+  var scanner = new PlayApiScanner()
+  ScannerFactory.setScanner(scanner)
+  val route = new RouteWrapper(routesRules)
+  RouteFactory.setRoute(route)
+
+  "ApiListingCache" should {
+
+    "load all API specs" in {
+
+      val docRoot = ""
+      val swagger = ApiListingCache.listing(docRoot, "127.0.0.1")
+
+      Logger.debug ("swagger: " + toJsonString(swagger))
+      swagger must beSome
+
+      swagger must beSome
+      swagger.get.getSwagger must beEqualTo("2.0")
+      swagger.get.getBasePath must beEqualTo(basePath)
+      swagger.get.getPaths.size must beEqualTo(7)
+      swagger.get.getDefinitions.size must beEqualTo(5)
+      swagger.get.getHost must beEqualTo(swaggerConfig.getHost)
+      swagger.get.getInfo.getContact.getName must beEqualTo(swaggerConfig.getContact)
+      swagger.get.getInfo.getVersion must beEqualTo(swaggerConfig.getVersion)
+      swagger.get.getInfo.getTitle must beEqualTo(swaggerConfig.getTitle)
+      swagger.get.getInfo.getTermsOfService must beEqualTo(swaggerConfig.getTermsOfServiceUrl)
+      swagger.get.getInfo.getLicense.getName must beEqualTo(swaggerConfig.getLicense)
+
+      val pathDoc = swagger.get.getPaths.get("/document/{settlementId}/files/{fileId}/accept")
+      pathDoc.getOperations.size must beEqualTo(1)
+
+      val opDocPost = pathDoc.getOperationMap.get(HttpMethod.POST)
+      opDocPost.getOperationId must beEqualTo("acceptsettlementfile")
+      opDocPost.getParameters.size() must beEqualTo(3)
+      opDocPost.getParameters.get(0).getDescription must beEqualTo("Id of the settlement to accept a file on.")
+      opDocPost.getParameters.get(1).getDescription must beEqualTo("File id of the file to accept.")
+
+      val pathSearch = swagger.get.getPaths.get("/search")
+      pathSearch.getOperations.size must beEqualTo(1)
+
+      val opSearchGet = pathSearch.getOperationMap.get(HttpMethod.GET)
+      opSearchGet.getParameters.size() must beEqualTo(3)
+      opSearchGet.getDescription must beEqualTo("Search for a settlement with personal number and property id.")
+      opSearchGet.getParameters.get(0).getDescription must beEqualTo("A personal number of one of the sellers.")
+      opSearchGet.getParameters.get(1).getDescription must beEqualTo("The cadastre or share id.")
+
+      val pathPOI = swagger.get.getPaths.get("/pointsofinterest")
+      pathPOI.getOperations.size must beEqualTo(1)
+
+      val opPOIGet = pathPOI.getOperationMap.get(HttpMethod.GET)
+      opPOIGet.getParameters.size() must beEqualTo(5)
+      opPOIGet.getDescription must beEqualTo("Returns points of interest")
+      opPOIGet.getParameters.get(0).getDescription must beEqualTo("Minimum easting for provided extent")
+      opPOIGet.getParameters.get(1).getDescription must beEqualTo("Minimum northing for provided extent")
+      opPOIGet.getParameters.get(2).getDescription must beEqualTo("Maximum easting for provided extent")
+      opPOIGet.getParameters.get(3).getDescription must beEqualTo("Maximum northing for provided extent")
+
+      val pathCat = swagger.get.getPaths.get("/cat")
+      pathCat.getOperations.size must beEqualTo(2)
+
+      val opCatGet = pathCat.getOperationMap.get(HttpMethod.GET)
+      opCatGet.getOperationId must beEqualTo("listCats")
+      opCatGet.getParameters must beEmpty
+      opCatGet.getConsumes must beNull
+      opCatGet.getResponses.get("200").getSchema.asInstanceOf[ArrayProperty].getItems.asInstanceOf[RefProperty].getSimpleRef must beEqualTo("Cat")
+      opCatGet.getProduces must beNull
+
+      val opCatPut = pathCat.getOperationMap.get(HttpMethod.PUT)
+      opCatPut.getOperationId must beEqualTo("add1")
+      opCatPut.getParameters.head.getName must beEqualTo("cat")
+      opCatPut.getParameters.head.getIn must beEqualTo("body")
+      opCatPut.getParameters.head.asInstanceOf[BodyParameter].getSchema.getReference must beEqualTo("#/definitions/Cat")
+      opCatPut.getConsumes must beNull
+      opCatPut.getResponses.get("200").getSchema.asInstanceOf[RefProperty].getSimpleRef must beEqualTo("ActionAnyContent")
+      opCatPut.getProduces must beNull
+
+      val pathCat43 = swagger.get.getPaths.get("/cat43")
+      pathCat43.getOperations.size must beEqualTo(1)
+
+      val opCatGet43 = pathCat43.getOperationMap.get(HttpMethod.GET)
+      opCatGet43.getOperationId must beEqualTo("test issue #43_nick")
+      opCatGet43.getResponses.get("200").getSchema.asInstanceOf[ArrayProperty].getItems.asInstanceOf[RefProperty].getSimpleRef must beEqualTo("Cat")
+
+      opCatGet43.getParameters.head.getName must beEqualTo("test_issue_43_param")
+      opCatGet43.getParameters.head.getIn must beEqualTo("query")
+      opCatGet43.getParameters.head.asInstanceOf[QueryParameter].getType must beEqualTo("integer")
+
+      opCatGet43.getParameters.get(1).getName must beEqualTo("test_issue_43_implicit_param")
+      opCatGet43.getParameters.get(1).getIn must beEqualTo("query")
+      opCatGet43.getParameters.get(1).asInstanceOf[QueryParameter].getType must beEqualTo("integer")
+
+
+
+      val pathDog = swagger.get.getPaths.get("/dog")
+      pathDog.getOperations.size must beEqualTo(2)
+
+      val opDogGet = pathDog.getOperationMap.get(HttpMethod.GET)
+      opDogGet.getOperationId must beEqualTo("listDogs")
+      opDogGet.getParameters must beEmpty
+      opDogGet.getConsumes.asScala.toList must beEqualTo(List("application/json","application/xml"))
+      opDogGet.getResponses.get("200").getSchema.asInstanceOf[ArrayProperty].getItems.asInstanceOf[RefProperty].getSimpleRef must beEqualTo("Dog")
+      opDogGet.getProduces.asScala.toList must beEqualTo(List("application/json","application/xml"))
+
+      val opDogPut = pathDog.getOperationMap.get(HttpMethod.PUT)
+      opDogPut.getOperationId must beEqualTo("add1")
+      opDogPut.getParameters.head.getName must beEqualTo("dog")
+      opDogPut.getParameters.head.getIn must beEqualTo("body")
+      opDogPut.getParameters.head.asInstanceOf[BodyParameter].getSchema.getReference must beEqualTo("#/definitions/Dog")
+      opDogPut.getConsumes.asScala.toList must beEqualTo(List("application/json","application/xml"))
+      opDogPut.getResponses.get("200").getSchema.asInstanceOf[RefProperty].getSimpleRef must beEqualTo("ActionAnyContent")
+      opDogPut.getProduces.asScala.toList must beEqualTo(List("application/json","application/xml"))
+
+      val pathDogParam = swagger.get.getPaths.get("/dog/{id}")
+      pathDogParam.getOperations.size must beEqualTo(1)
+
+      val opDogParamPut = pathDogParam.getOperationMap.get(HttpMethod.PUT)
+      opDogParamPut.getOperationId must beEqualTo("add0")
+      opDogParamPut.getParameters.head.getName must beEqualTo("id")
+      opDogParamPut.getParameters.head.getIn must beEqualTo("path")
+      opDogParamPut.getParameters.head.asInstanceOf[PathParameter].getType must beEqualTo("string")
+      opDogParamPut.getConsumes.asScala.toList must beEqualTo(List("application/json","application/xml"))
+      opDogParamPut.getProduces.asScala.toList must beEqualTo(List("application/json","application/xml"))
+      opDogParamPut.getResponses.get("200").getSchema.asInstanceOf[RefProperty].getSimpleRef must beEqualTo("ActionAnyContent")
+
+      val catDef = swagger.get.getDefinitions.get("Cat").asInstanceOf[ModelImpl]
+      catDef.getType must beEqualTo("object")
+      catDef.getProperties.containsKey("id") must beTrue
+      catDef.getProperties.containsKey("name") must beTrue
+
+      val dogDef = swagger.get.getDefinitions.get("Dog").asInstanceOf[ModelImpl]
+      dogDef.getType must beEqualTo("object")
+      dogDef.getProperties.containsKey("id") must beTrue
+      dogDef.getProperties.containsKey("name") must beTrue
+    }
+  }
+
+  def toJsonString(data: Any): String = {
+    if (data.getClass.equals(classOf[String])) {
+      data.asInstanceOf[String]
+    } else {
+      Json.pretty(data.asInstanceOf[AnyRef])
+    }
+  }
+}
+

--- a/play-2.5/swagger-play2/test/PlayApiListingCacheSpec.scala
+++ b/play-2.5/swagger-play2/test/PlayApiListingCacheSpec.scala
@@ -36,7 +36,7 @@ PUT /api/dog/:id testdata.DogController.add0(id:String)
     }
   }
 
-  val routesRules = Map(routesList map 
+  val routesRules = Map(routesList map
   { route =>
     {
       val routeName = s"${route.call.packageName}.${route.call.controller}$$.${route.call.method}"
@@ -80,7 +80,7 @@ PUT /api/dog/:id testdata.DogController.add0(id:String)
       swagger.get.getSwagger must beEqualTo("2.0")
       swagger.get.getBasePath must beEqualTo(basePath)
       swagger.get.getPaths.size must beEqualTo(7)
-      swagger.get.getDefinitions.size must beEqualTo(5)
+      swagger.get.getDefinitions.size must beEqualTo(6)
       swagger.get.getHost must beEqualTo(swaggerConfig.getHost)
       swagger.get.getInfo.getContact.getName must beEqualTo(swaggerConfig.getContact)
       swagger.get.getInfo.getVersion must beEqualTo(swaggerConfig.getVersion)
@@ -204,4 +204,3 @@ PUT /api/dog/:id testdata.DogController.add0(id:String)
     }
   }
 }
-

--- a/play-2.5/swagger-play2/test/PlayApiScannerSpec.scala
+++ b/play-2.5/swagger-play2/test/PlayApiScannerSpec.scala
@@ -1,0 +1,52 @@
+import java.io.File
+
+import play.modules.swagger._
+import org.specs2.mutable._
+import org.specs2.mock.Mockito
+import scala.collection.JavaConversions._
+import play.modules.swagger.util.SwaggerContext
+import play.routes.compiler.{ Route => PlayRoute }
+
+class PlayApiScannerSpec extends Specification with Mockito {
+
+  // set up mock for Play Router
+  val routesList = {
+    play.routes.compiler.RoutesFileParser.parseContent("""
+GET /api/dog testdata.DogController.list
+PUT /api/dog testdata.DogController.add1
+GET /api/cat @testdata.CatController.list
+PUT /api/cat @testdata.CatController.add1
+GET /api/fly testdata.FlyController.list
+PUT /api/dog testdata.DogController.add1
+PUT /api/dog/:id testdata.DogController.add0(id:String)
+                                                       """, new File("")).right.get.collect {
+      case (route: PlayRoute) => {
+        val routeName = s"${route.call.packageName}.${route.call.controller}$$.${route.call.method}"
+        route
+      }
+    }
+  }
+
+  val routesRules = Map(routesList map 
+  { route =>
+    {
+      val routeName = s"${route.call.packageName}.${route.call.controller}$$.${route.call.method}"
+      routeName -> route
+    }
+  } : _*)
+
+
+  val route = new RouteWrapper(routesRules)
+  RouteFactory.setRoute(route)
+
+  "PlayApiScanner" should {
+    "identify correct API classes based on router and API annotations" in {
+      val classes = new PlayApiScanner().classes()
+      
+      classes.toList.length must beEqualTo(2)
+      classes.contains(SwaggerContext.loadClass("testdata.DogController")) must beTrue
+      classes.contains(SwaggerContext.loadClass("testdata.CatController")) must beTrue
+    }
+  }
+
+}

--- a/play-2.5/swagger-play2/test/testdata/CatController.scala
+++ b/play-2.5/swagger-play2/test/testdata/CatController.scala
@@ -1,0 +1,72 @@
+package testdata
+
+import io.swagger.annotations._
+
+import play.api.mvc.{Action, Controller}
+
+@Api(value = "/apitest/cats", description = "play with cats")
+class CatController extends Controller {
+
+  @ApiOperation(value = "addCat1",
+      httpMethod = "PUT",
+      authorizations = Array(),
+      consumes = "",
+      protocols = "")
+    @ApiImplicitParams(Array(
+      new ApiImplicitParam(name = "cat", value = "Cat object to add", required = true, dataType = "testdata.Cat", paramType = "body")))
+    def add1 = Action {
+      request => Ok("test case")
+    }
+
+    @ApiOperation(value = "Updates a new Cat",
+      notes = "Updates cats nicely",
+      httpMethod = "POST")
+    @ApiResponses(Array(
+      new ApiResponse(code = 405, message = "Invalid input")))
+    @ApiImplicitParams(Array(
+      new ApiImplicitParam(name = "cat", value = "Cat object to update", required = true, dataType = "testdata.Cat", paramType = "body")))
+    def update = Action {
+      request => Ok("test case")
+    }
+
+    @ApiOperation(value = "Get Cat by Id",
+      notes = "Returns a cat",
+      response = classOf[Cat],
+      httpMethod = "GET",
+      produces = "")
+    @ApiResponses(Array(
+      new ApiResponse(code = 405, message = "Invalid input"),
+      new ApiResponse(code = 404, message = "Cat not found")))
+    def get1(@ApiParam(value = "ID of cat to fetch", required = true) id: Long) = Action {
+      request => Ok("test case")
+    }
+
+    @ApiOperation(value = "List Cats",
+      nickname = "listCats",
+      notes = "Returns all cats",
+      response = classOf[Cat],
+      responseContainer = "List",
+      httpMethod = "GET")
+    @Deprecated
+    def list = Action {
+      request => Ok("test case")
+    }
+
+    def no_route = Action {
+      request => Ok("test case")
+    }
+
+  @ApiOperation(value = "test issue #43",
+    nickname = "test issue #43_nick",
+    notes = "test issue #43_notes",
+    response = classOf[testdata.Cat],
+    responseContainer = "List",
+    httpMethod = "GET")
+  @ApiImplicitParams(Array(
+    new ApiImplicitParam(name = "test_issue_43_implicit_param", dataType = "Option[Int]", value = "test issue #43 implicit param", paramType = "query")))
+  def testIssue43(test_issue_43_param:  Option[Int]) = Action {
+    request => Ok("test issue #43")
+  }
+}
+
+case class Cat(id: Long, name: String)

--- a/play-2.5/swagger-play2/test/testdata/ClassWithApi.java
+++ b/play-2.5/swagger-play2/test/testdata/ClassWithApi.java
@@ -1,0 +1,8 @@
+package testdata;
+
+import io.swagger.annotations.Api;
+
+@Api(basePath = "//", description = "sddsdsds", tags = {"asdsasad"})
+public class ClassWithApi {
+
+}

--- a/play-2.5/swagger-play2/test/testdata/DocumentController.scala
+++ b/play-2.5/swagger-play2/test/testdata/DocumentController.scala
@@ -1,0 +1,26 @@
+package testdata
+
+import io.swagger.annotations._
+
+import play.api.mvc.Controller
+import play.mvc.{Result, Http}
+
+@Api(value = "/apitest/document", description = "documents", tags = Array("Documents"))
+class DocumentController extends Controller {
+
+  @ApiOperation(value = "Register acceptance of a file on a settlement",
+    notes = "Accept file",
+    httpMethod = "POST",
+    nickname = "acceptsettlementfile",
+    produces = "application/json")
+  @ApiResponses(Array(
+    new ApiResponse(code = Http.Status.BAD_REQUEST, message = "Bad Request"),
+    new ApiResponse(code = Http.Status.UNAUTHORIZED, message = "Unauthorized"),
+    new ApiResponse(code = Http.Status.INTERNAL_SERVER_ERROR, message = "Server error")))
+  @ApiImplicitParams(Array(
+    new ApiImplicitParam(value = "Token for logged in user.", name = "Authorization", required = false, dataType = "string", paramType = "header")))
+  def accept(@ApiParam(value = "Id of the settlement to accept a file on.") settlementId: String,
+          @ApiParam(value = "File id of the file to accept.") fileId: String): Result = {
+    play.mvc.Results.ok
+  }
+}

--- a/play-2.5/swagger-play2/test/testdata/Dog.scala
+++ b/play-2.5/swagger-play2/test/testdata/Dog.scala
@@ -1,0 +1,6 @@
+package testdata
+
+class Dog{
+  var id: Long = _
+  var name: String = _
+}

--- a/play-2.5/swagger-play2/test/testdata/DogController.scala
+++ b/play-2.5/swagger-play2/test/testdata/DogController.scala
@@ -1,0 +1,185 @@
+package testdata
+
+import io.swagger.annotations._
+import play.api.mvc.{Action, Controller}
+import scala.concurrent.Future
+
+// todo - test for these
+@Api(value = "/apitest/dogs", description = "look after the dogs",
+  basePath = "xx",
+  position = 2,
+  produces = "application/json, application/xml",
+  consumes = "application/json, application/xml",
+  protocols = "http, https",
+  authorizations = Array(new Authorization(value="oauth2",
+    scopes = Array(
+      new AuthorizationScope(scope = "vet", description = "vet access"),
+      new AuthorizationScope(scope = "owner", description = "owner access")
+    ))
+  )
+)
+object DogController extends Controller {
+
+  @ApiOperation(value="addDog0")
+  def add0(id:String) = Action {
+    request => Ok("test case")
+  }
+
+  @ApiOperation(value = "addDog1",
+    httpMethod = "PUT")
+  @ApiImplicitParams(Array(
+    new ApiImplicitParam(name = "dog", value = "Dog object to add", required = true, dataType = "testdata.Dog", paramType = "body")))
+  def add1 = Action {
+    request => Ok("test case")
+  }
+
+  @ApiOperation(value = "addDog2",
+    notes = "Adds a dogs better",
+    httpMethod = "PUT",
+    nickname = "addDog2_nickname",
+    authorizations = Array(new Authorization(value="oauth2",
+      scopes = Array(
+        new AuthorizationScope(scope = "vet", description = "vet access"),
+        new AuthorizationScope(scope = "owner", description = "owner access")
+      ))
+    ),
+    consumes = " application/json ",
+    protocols = "http",
+    position = 2)
+  @ApiResponses(Array())
+  @ApiImplicitParams(Array(
+    new ApiImplicitParam(name = "dog", value = "Dog object to add", required = true, dataType = "testdata.Dog", paramType = "body")))
+  def add2 = Action {
+    request => Ok("test case")
+  }
+
+  @ApiOperation(value = "Add a new Dog",
+    notes = "Adds a dogs nicely",
+    httpMethod = "PUT",
+    authorizations = Array(new Authorization(value="oauth2",
+      scopes = Array(
+        new AuthorizationScope(scope = "vet", description = "vet access"),
+        new AuthorizationScope(scope = "owner", description = "owner access")
+      )),
+      new Authorization(value="api_key")
+    ),
+    consumes = " application/json, text/yaml ",
+    protocols = "http, https"
+  )
+  @ApiResponses(Array(
+    new ApiResponse(code = 405, message = "Invalid input"),
+    new ApiResponse(code = 666, message = "Big Problem")))
+  @ApiImplicitParams(Array(
+    new ApiImplicitParam(name = "dog", value = "Dog object to add", required = true, dataType = "testdata.Dog", paramType = "body")))
+  def add3 = Action {
+    request => Ok("test case")
+  }
+
+  @ApiOperation(value = "Updates a new Dog",
+    notes = "Updates dogs nicely",
+    httpMethod = "POST")
+  @ApiResponses(Array(
+    new ApiResponse(code = 405, message = "Invalid input")))
+  @ApiImplicitParams(Array(
+    new ApiImplicitParam(name = "dog", value = "Dog object to update", required = true, dataType = "testdata.Dog", paramType = "body")))
+  def update = Action {
+    request => Ok("test case")
+  }
+
+  @ApiOperation(value = "Get Dog by Id",
+    notes = "Returns a dog",
+    response = classOf[Dog],
+    httpMethod = "GET",
+    produces = "")
+  @ApiResponses(Array(
+    new ApiResponse(code = 405, message = "Invalid input"),
+    new ApiResponse(code = 404, message = "Dog not found")))
+  def get1(@ApiParam(value = "ID of dog to fetch", required = true) id: Long) = Action {
+    request => Ok("test case")
+  }
+
+  @ApiOperation(value = "Get Dog by Id",
+    notes = "Returns a dog",
+    response = classOf[Dog],
+    httpMethod = "GET",
+    produces = "application/json")
+  @ApiResponses(Array(
+    new ApiResponse(code = 405, message = "Invalid input"),
+    new ApiResponse(code = 404, message = "Dog not found")))
+  def get2(@ApiParam(value = "ID of dog to fetch", required = true) id: Long) = Action {
+    request => Ok("test case")
+  }
+
+  @ApiOperation(value = "Get Dog by Id",
+    notes = "Returns a dog",
+    response = classOf[Dog],
+    httpMethod = "GET",
+    produces = "application/json, application/xml")
+  @ApiResponses(Array(
+    new ApiResponse(code = 405, message = "Invalid input"),
+    new ApiResponse(code = 404, message = "Dog not found")))
+  def get3(@ApiParam(value = "ID of dog to fetch", required = true) id: Long) = Action {
+    request => Ok("test case")
+  }
+
+  /*   Not Supported....routing is done elsewhere...
+  - although could use this with a custom routing module
+  -- one day..
+  @GET
+  @Path("/{petId}")
+  */
+
+  @ApiOperation(value = "List Dogs",
+    nickname = "listDogs",
+    notes = "Returns all dogs",
+    response = classOf[Dog],
+    responseContainer = "List",
+    httpMethod = "GET")
+  @Deprecated
+  def list = Action {
+    request => Ok("test case")
+  }
+
+  @ApiOperation(value = "Method with numeric chars in name",
+    notes = "get a Dog with id 33",
+    httpMethod = "GET")
+  @ApiResponses(Array(
+    new ApiResponse(code = 404, message = "Dog not found")))
+  def get33 = Action {
+    request => Ok("test case")
+  }
+
+  // use the Jax.ws annotations
+  // Delete a Dog
+  @ApiOperation(value = "Delete", notes = "Deletes a user", httpMethod = "DELETE")
+  def delete(
+              @ApiParam(name = "dogId", value = "dogId") userId: String)
+  = Action.async {
+    implicit request => Future.successful(Ok)
+  }
+
+  @ApiOperation(value = "valueStr", notes = "notesStr", httpMethod = "GET")
+  @Deprecated
+  def deprecated = Action {
+    request => Ok("test case")
+  }
+
+  def no_annotations = Action {
+    request => Ok("test case")
+  }
+
+  def no_route = Action {
+    request => Ok("test case")
+  }
+
+  @ApiOperation(value = "unknown method name",
+    httpMethod = "UNKNOWN")
+  def unknown_method() = Action {
+    request => Ok("test case")
+  }
+
+  @ApiOperation(value = "undefined method name")
+  def undefined_method() = Action {
+    request => Ok("test case")
+  }
+}

--- a/play-2.5/swagger-play2/test/testdata/FlyController.scala
+++ b/play-2.5/swagger-play2/test/testdata/FlyController.scala
@@ -1,0 +1,14 @@
+package testdata
+
+import play.api.mvc.{Action, Controller}
+
+object FlyController extends Controller {
+
+  def list = Action {
+    request =>
+      Ok("test case")
+  }
+
+}
+
+case class Fly(id: Long, name: String)

--- a/play-2.5/swagger-play2/test/testdata/Person.scala
+++ b/play-2.5/swagger-play2/test/testdata/Person.scala
@@ -1,0 +1,7 @@
+package testdata
+
+import com.avaje.ebean.Model
+
+class Person extends Model {
+  var name: String = _
+}

--- a/play-2.5/swagger-play2/test/testdata/PointOfInterestController.scala
+++ b/play-2.5/swagger-play2/test/testdata/PointOfInterestController.scala
@@ -1,0 +1,27 @@
+package testdata
+
+import io.swagger.annotations._
+import play.api.mvc.Controller
+import play.mvc.{Result, Http}
+
+@Api(value = "/apitest/pointsofinterest", description = "Points of interest")
+class PointOfInterestController extends Controller {
+
+  @ApiOperation(value = "Get points of interest",
+    notes = "Returns points of interest",
+    httpMethod = "GET",
+    nickname = "pointsofinterest",
+    produces = "application/json")
+  @ApiResponses(Array(
+    new ApiResponse(code = Http.Status.BAD_REQUEST, message = "Bad Request"),
+    new ApiResponse(code = Http.Status.UNAUTHORIZED, message = "Unauthorized"),
+    new ApiResponse(code = Http.Status.INTERNAL_SERVER_ERROR, message = "Server error")))
+  @ApiImplicitParams(Array(
+    new ApiImplicitParam(value = "Token for logged in user.", name = "Authorization", required = false, dataType = "string", paramType = "header")))
+  def list(@ApiParam(value = "Minimum easting for provided extent", required = true, defaultValue = "-19448.67") eastingMin: Double,
+          @ApiParam(value = "Minimum northing for provided extent", required = true, defaultValue = "2779504.82") northingMin: Double,
+          @ApiParam(value = "Maximum easting for provided extent", required = true, defaultValue = "-17557.26") eastingMax: Double,
+          @ApiParam(value = "Maximum northing for provided extent", required = true, defaultValue = "2782860.09") northingMax: Double): Result = {
+    play.mvc.Results.ok
+  }
+}

--- a/play-2.5/swagger-play2/test/testdata/SettlementsSearcherController.java
+++ b/play-2.5/swagger-play2/test/testdata/SettlementsSearcherController.java
@@ -1,0 +1,46 @@
+package testdata;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.annotations.*;
+import play.mvc.Controller;
+import play.mvc.Http;
+import play.mvc.Result;
+
+import java.util.List;
+
+@Api(value = "/apitest/search", description = "Search for settlements", tags = {"Search"})
+public class SettlementsSearcherController extends Controller {
+
+  @ApiOperation(value = "Search for settlement", notes = "Search for a settlement with personal number and property id.", httpMethod = "GET", nickname = "getsettlement", produces = "application/json", response = Settlement.class, responseContainer = "List")
+  @ApiResponses({
+      @ApiResponse(code = Http.Status.BAD_REQUEST, message = "Bad Request"),
+      @ApiResponse(code = Http.Status.UNAUTHORIZED, message = "Unauthorized"),
+      @ApiResponse(code = Http.Status.INTERNAL_SERVER_ERROR, message = "Server error")
+  })
+  @ApiImplicitParams({
+      @ApiImplicitParam(value = "Token for logged in user", name = "Authorization", required = false, dataType = "string", paramType = "header"),
+  })
+  public Result search(
+      @ApiParam(value = "A personal number of one of the sellers.", example = "0101201112345") String personalNumber,
+      @ApiParam(value = "The cadastre or share id.", example = "1201-5-1-0-0", required = true) String propertyId) {
+    return ok();
+  }
+}
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+class Settlement {
+
+  @ApiModelProperty(required = true)
+  public String settlementId;
+
+  @ApiModelProperty(required = true)
+  public List<String> sellers;
+
+  @ApiModelProperty
+  public List<String> buyers;
+
+  @ApiModelProperty
+  public Integer purchaseAmount;
+
+}
+


### PR DESCRIPTION
Usage of Source instead of Enumerator as recommended in
https://www.playframework.com/documentation/2.5.x/Migration25

Modifications in the SwaggerPlugin constructor:
We do not inject the application, but to avoid a circular dependency
we inject the environment and the configuration.

In order to not modify swagger-scala-module, I've added in the build.sbt
the jackson-module-scala dependence with the same version as the jackson
version used by play 2.5.1.
