### PR TITLE
disabling the listing cache

### DIFF
--- a/play-2.4/swagger-play2/app/play/modules/swagger/ApiListingCache.scala
+++ b/play-2.4/swagger-play2/app/play/modules/swagger/ApiListingCache.scala
@@ -8,7 +8,7 @@ object ApiListingCache {
   var cache: Option[Swagger] = None
 
   def listing(docRoot: String, host: String): Option[Swagger] = {
-    cache.orElse {
+    //cache.orElse {
       Logger("swagger").debug("Loading API metadata")
 
       val scanner = ScannerFactory.getScanner()
@@ -24,10 +24,14 @@ object ApiListingCache {
           // no config, do nothing
         }
       }
-      cache = Some(swagger)
-      cache
-    }
-    cache.get.setHost(host)
-    cache
+
+      Some(swagger)
+
+      //cache = Some(swagger)
+      //cache
+    //}
+
+    //cache.get.setHost(host)
+    //cache
   }
 }

--- a/play-2.4/swagger-play2/test/PlayApiListingCacheSpec.scala
+++ b/play-2.4/swagger-play2/test/PlayApiListingCacheSpec.scala
@@ -65,7 +65,7 @@ PUT /api/dog/:id testdata.DogController.add0(id:String)
   ScannerFactory.setScanner(scanner)
   val route = new RouteWrapper(routesRules)
   RouteFactory.setRoute(route)
-
+  
   "ApiListingCache" should {
 
     "load all API specs" in {
@@ -193,6 +193,20 @@ PUT /api/dog/:id testdata.DogController.add0(id:String)
       dogDef.getType must beEqualTo("object")
       dogDef.getProperties.containsKey("id") must beTrue
       dogDef.getProperties.containsKey("name") must beTrue
+    }
+
+    "cache contains all paths after filtering" in {
+      val docRoot = ""
+      val swaggerAll = ApiListingCache.listing(docRoot, "127.0.0.1")
+      swaggerAll.get.getPaths.size must beEqualTo(7)
+
+      val swaggerCat = ApiListingCache.listing(docRoot, "127.0.0.1")
+      swaggerCat.get.setPaths(swaggerCat.get.getPaths.filterKeys(_.startsWith("/cat") ))
+      swaggerCat.get.getPaths.size must beEqualTo(2)
+
+      val swaggerDog = ApiListingCache.listing(docRoot, "127.0.0.1")
+      swaggerDog.get.setPaths(swaggerDog.get.getPaths.filterKeys(_.startsWith("/dog") ))
+      swaggerDog.get.getPaths.size must beEqualTo(2)
     }
   }
 


### PR DESCRIPTION
The cache can be modified from outside like in ApiHelpController.getApiListing where the swagger paths are filtered. After doing that with different paths nothing is left and swagger-ui doesn't show anything.

Issue #91
