### PR TITLE
using cloner to make a deep clone of the cache before returning it

### DIFF
--- a/play-2.4/swagger-play2/app/play/modules/swagger/ApiListingCache.scala
+++ b/play-2.4/swagger-play2/app/play/modules/swagger/ApiListingCache.scala
@@ -8,7 +8,7 @@ object ApiListingCache {
   var cache: Option[Swagger] = None
 
   def listing(docRoot: String, host: String): Option[Swagger] = {
-    cache.orElse {
+    //cache.orElse {
       Logger("swagger").debug("Loading API metadata")
 
       val scanner = ScannerFactory.getScanner()
@@ -24,10 +24,14 @@ object ApiListingCache {
           // no config, do nothing
         }
       }
-      cache = Some(swagger)
-      cache
-    }
-    cache.get.setHost(host)
-    cache
+
+      Some(swagger)
+
+      //cache = Some(swagger)
+      //cache
+    //}
+
+    //cache.get.setHost(host)
+    //cache
   }
 }

--- a/play-2.4/swagger-play2/app/play/modules/swagger/ApiListingCache.scala
+++ b/play-2.4/swagger-play2/app/play/modules/swagger/ApiListingCache.scala
@@ -1,5 +1,6 @@
 package play.modules.swagger
 
+import com.rits.cloning.Cloner
 import io.swagger.config._
 import io.swagger.models.Swagger
 import play.api.Logger
@@ -8,7 +9,9 @@ object ApiListingCache {
   var cache: Option[Swagger] = None
 
   def listing(docRoot: String, host: String): Option[Swagger] = {
-    //cache.orElse {
+    val cloner = new Cloner();
+
+    cache.orElse {
       Logger("swagger").debug("Loading API metadata")
 
       val scanner = ScannerFactory.getScanner()
@@ -25,13 +28,13 @@ object ApiListingCache {
         }
       }
 
-      Some(swagger)
+      cache = Some(swagger)
+      val clone = cloner.deepClone(cache)
+      clone
+    }
 
-      //cache = Some(swagger)
-      //cache
-    //}
-
-    //cache.get.setHost(host)
-    //cache
+    cache.get.setHost(host)
+    val clone = cloner.deepClone(cache)
+    clone
   }
 }

--- a/play-2.4/swagger-play2/build.sbt
+++ b/play-2.4/swagger-play2/build.sbt
@@ -12,6 +12,7 @@ libraryDependencies ++= Seq(
   "io.swagger"         % "swagger-core"               % "1.5.12",
   "io.swagger"        %% "swagger-scala-module"       % "1.0.3",
   "com.typesafe.play" %% "routes-compiler"            % "2.4.6",
+  "uk.com.robust-it"   % "cloning"                    % "1.9.2",
   "com.typesafe.play" %% "play-ebean"                 % "2.0.0"            % "test",
   "org.specs2"        %% "specs2-core"                % "3.8.7"            % "test",
   "org.specs2"        %% "specs2-mock"                % "3.8.7"            % "test",

--- a/play-2.4/swagger-play2/test/PlayApiListingCacheSpec.scala
+++ b/play-2.4/swagger-play2/test/PlayApiListingCacheSpec.scala
@@ -65,7 +65,7 @@ PUT /api/dog/:id testdata.DogController.add0(id:String)
   ScannerFactory.setScanner(scanner)
   val route = new RouteWrapper(routesRules)
   RouteFactory.setRoute(route)
-
+  
   "ApiListingCache" should {
 
     "load all API specs" in {
@@ -191,6 +191,20 @@ PUT /api/dog/:id testdata.DogController.add0(id:String)
       dogDef.getType must beEqualTo("object")
       dogDef.getProperties.containsKey("id") must beTrue
       dogDef.getProperties.containsKey("name") must beTrue
+    }
+
+    "cache contains all paths after filtering" in {
+      val docRoot = ""
+      val swaggerAll = ApiListingCache.listing(docRoot, "127.0.0.1")
+      swaggerAll.get.getPaths.size must beEqualTo(7)
+
+      val swaggerCat = ApiListingCache.listing(docRoot, "127.0.0.1")
+      swaggerCat.get.setPaths(swaggerCat.get.getPaths.filterKeys(_.startsWith("/cat") ))
+      swaggerCat.get.getPaths.size must beEqualTo(2)
+
+      val swaggerDog = ApiListingCache.listing(docRoot, "127.0.0.1")
+      swaggerDog.get.setPaths(swaggerDog.get.getPaths.filterKeys(_.startsWith("/dog") ))
+      swaggerDog.get.getPaths.size must beEqualTo(2)
     }
   }
 

--- a/play-2.5/swagger-play2/app/play/modules/swagger/ApiListingCache.scala
+++ b/play-2.5/swagger-play2/app/play/modules/swagger/ApiListingCache.scala
@@ -1,5 +1,6 @@
 package play.modules.swagger
 
+import com.rits.cloning.Cloner
 import io.swagger.config._
 import io.swagger.models.Swagger
 import play.api.Logger
@@ -8,6 +9,8 @@ object ApiListingCache {
   var cache: Option[Swagger] = None
 
   def listing(docRoot: String, host: String): Option[Swagger] = {
+    val cloner = new Cloner();
+
     cache.orElse {
       Logger("swagger").debug("Loading API metadata")
 
@@ -25,9 +28,11 @@ object ApiListingCache {
         }
       }
       cache = Some(swagger)
-      cache
+      val clone = cloner.deepClone(cache)
+      clone
     }
     cache.get.setHost(host)
-    cache
+    val clone = cloner.deepClone(cache)
+    clone
   }
 }

--- a/play-2.5/swagger-play2/build.sbt
+++ b/play-2.5/swagger-play2/build.sbt
@@ -13,6 +13,7 @@ libraryDependencies ++= Seq(
   "io.swagger"         % "swagger-core"               % "1.5.12",
   "io.swagger"        %% "swagger-scala-module"       % "1.0.3",
   "com.typesafe.play" %% "routes-compiler"            % "2.5.4",
+  "uk.com.robust-it"   % "cloning"                    % "1.9.2",
   "com.typesafe.play" %% "play-ebean"                 % "2.0.0"            % "test",
   "org.specs2"        %% "specs2-core"                % "3.8.7"            % "test",
   "org.specs2"        %% "specs2-mock"                % "3.8.7"            % "test",

--- a/play-2.5/swagger-play2/test/PlayApiListingCacheSpec.scala
+++ b/play-2.5/swagger-play2/test/PlayApiListingCacheSpec.scala
@@ -192,6 +192,20 @@ PUT /api/dog/:id testdata.DogController.add0(id:String)
       dogDef.getProperties.containsKey("id") must beTrue
       dogDef.getProperties.containsKey("name") must beTrue
     }
+
+    "cache contains all paths after filtering" in {
+      val docRoot = ""
+      val swaggerAll = ApiListingCache.listing(docRoot, "127.0.0.1")
+      swaggerAll.get.getPaths.size must beEqualTo(7)
+
+      val swaggerCat = ApiListingCache.listing(docRoot, "127.0.0.1")
+      swaggerCat.get.setPaths(swaggerCat.get.getPaths.filterKeys(_.startsWith("/cat") ))
+      swaggerCat.get.getPaths.size must beEqualTo(2)
+
+      val swaggerDog = ApiListingCache.listing(docRoot, "127.0.0.1")
+      swaggerDog.get.setPaths(swaggerDog.get.getPaths.filterKeys(_.startsWith("/dog") ))
+      swaggerDog.get.getPaths.size must beEqualTo(2)
+    }
   }
 
   def toJsonString(data: Any): String = {

--- a/play-2.6/swagger-play2/app/play/modules/swagger/ApiListingCache.scala
+++ b/play-2.6/swagger-play2/app/play/modules/swagger/ApiListingCache.scala
@@ -1,5 +1,6 @@
 package play.modules.swagger
 
+import com.rits.cloning.Cloner
 import io.swagger.config._
 import io.swagger.models.Swagger
 import play.api.Logger
@@ -8,6 +9,8 @@ object ApiListingCache {
   var cache: Option[Swagger] = None
 
   def listing(docRoot: String, host: String): Option[Swagger] = {
+    val cloner = new Cloner();
+
     cache.orElse {
       Logger("swagger").debug("Loading API metadata")
 
@@ -25,9 +28,11 @@ object ApiListingCache {
         }
       }
       cache = Some(swagger)
-      cache
+      val clone = cloner.deepClone(cache)
+      clone
     }
     cache.get.setHost(host)
-    cache
+    val clone = cloner.deepClone(cache)
+    clone
   }
 }

--- a/play-2.6/swagger-play2/build.sbt
+++ b/play-2.6/swagger-play2/build.sbt
@@ -13,6 +13,7 @@ libraryDependencies ++= Seq(
   "io.swagger"         % "swagger-core"               % "1.5.16",
   "io.swagger"        %% "swagger-scala-module"       % "1.0.5-SNAPSHOT",
   "com.typesafe.play" %% "routes-compiler"            % "2.6.0",
+  "uk.com.robust-it"   % "cloning"                    % "1.9.2",
   "com.typesafe.play" %% "play-ebean"                 % "4.0.2"            % "test",
   "org.specs2"        %% "specs2-core"                % "3.8.7"            % "test",
   "org.specs2"        %% "specs2-mock"                % "3.8.7"            % "test",


### PR DESCRIPTION
instead of disabling the cache it could be cloned before returning, so that just a clone is modified and not the cache itself. 

for cloning i introduced the cloning library (https://github.com/kostaskougios/cloning).

fixes #91
