### PR TITLE
scala 2.10 support for play-2.4 and play-2.5

### DIFF
--- a/play-2.4/swagger-play2/build.sbt
+++ b/play-2.4/swagger-play2/build.sbt
@@ -4,7 +4,7 @@ version := "1.5.3-SNAPSHOT"
 checksums in update := Nil
 
 scalaVersion:= "2.11.6"
-crossScalaVersions := Seq("2.11.6", "2.11.7")
+crossScalaVersions := Seq("2.11.6", "2.11.7", "2.10.6")
 
 libraryDependencies ++= Seq(
   "org.slf4j"          % "slf4j-api"                  % "1.6.4",

--- a/play-2.5/swagger-play2/build.sbt
+++ b/play-2.5/swagger-play2/build.sbt
@@ -4,6 +4,7 @@ version := "1.5.3.2"
 checksums in update := Nil
 
 scalaVersion:= "2.11.7"
+crossScalaVersions := Seq("2.11.7", "2.10.6")
 
 libraryDependencies ++= Seq(
   "com.fasterxml.jackson.module"  %% "jackson-module-scala"       % "2.7.2",


### PR DESCRIPTION
Adding cross-version building support for Scala 2.10 for play-2.4 and play-2.5
