### PR TITLE
Fix Issue #99: Format specifier '%s'

### DIFF
--- a/play-2.4/swagger-play2/app/play/modules/swagger/PlayReader.java
+++ b/play-2.4/swagger-play2/app/play/modules/swagger/PlayReader.java
@@ -584,7 +584,7 @@ public class PlayReader {
             Type[] genericParameterTypes = method.getGenericParameterTypes();
             return Json.mapper().getTypeFactory().constructType(genericParameterTypes[position], cls);
         } catch (Exception e) {
-            Logger.error(String.format("Exception getting parameter type for method %s, param %s at position %d"), e);
+            Logger.error(String.format("Exception getting parameter type for method %s, param %s at position %d", method, simpleTypeName, position), e);
             return null;
         }
 
@@ -594,7 +594,7 @@ public class PlayReader {
         try {
             return Arrays.asList(paramAnnotations[fieldPosition]);
         } catch (Exception e) {
-            Logger.error(String.format("Exception getting parameter type for method %s, param %s at position %d"), e);
+            Logger.error(String.format("Exception getting parameter type for %s at position %d", simpleTypeName, fieldPosition), e);
             return null;
         }
     }

--- a/play-2.5/swagger-play2/app/play/modules/swagger/PlayReader.java
+++ b/play-2.5/swagger-play2/app/play/modules/swagger/PlayReader.java
@@ -584,7 +584,7 @@ public class PlayReader {
             Type[] genericParameterTypes = method.getGenericParameterTypes();
             return Json.mapper().getTypeFactory().constructType(genericParameterTypes[position], cls);
         } catch (Exception e) {
-            Logger.error(String.format("Exception getting parameter type for method %s, param %s at position %d"), e);
+            Logger.error(String.format("Exception getting parameter type for method %s, param %s at position %d", method, simpleTypeName, position), e);
             return null;
         }
 
@@ -594,7 +594,7 @@ public class PlayReader {
         try {
             return Arrays.asList(paramAnnotations[fieldPosition]);
         } catch (Exception e) {
-            Logger.error(String.format("Exception getting parameter type for method %s, param %s at position %d"), e);
+            Logger.error(String.format("Exception getting parameter type for %s at position %d", simpleTypeName, fieldPosition), e);
             return null;
         }
     }


### PR DESCRIPTION
Fix two error handling routines that are throwing exceptions and obscuring legitimate parsing issues. 

Reflected in issue #99 and observed as an issue in PR #88. 

Error injecting constructor, java.util.MissingFormatArgumentException:
Format specifier '%s'
