### PR TITLE
Fix crossScalaVersions to target play 2.4 supported versions

### DIFF
--- a/play-2.4/swagger-play2/build.sbt
+++ b/play-2.4/swagger-play2/build.sbt
@@ -3,9 +3,9 @@ version := "1.5.4-SNAPSHOT"
 
 checksums in update := Nil
 
-scalaVersion := "2.10.6"
+scalaVersion := "2.11.8"
 
-crossScalaVersions := Seq("2.10.6", scalaVersion.value, "2.12.1")
+crossScalaVersions := Seq("2.10.6", scalaVersion.value)
 
 libraryDependencies ++= Seq(
   "org.slf4j"          % "slf4j-api"                  % "1.7.21",


### PR DESCRIPTION
I'm not sure what the intended `crossScalaVersions` should be but this fixes:
- `2.12.1` is not supported by play `2.4.x`
- `2.10.6` was referenced twice
- `2.11.x` support was missing

Thanks for reviewing this and maintaining swagger-play!