### PR TITLE
Handle route delegation properly

### DIFF
--- a/play-2.5/swagger-play2/build.sbt
+++ b/play-2.5/swagger-play2/build.sbt
@@ -76,3 +76,6 @@ pomExtra := {
 }
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
+
+resourceDirectory in Test := baseDirectory.value / "test-resources"
+parallelExecution in Test := false

--- a/play-2.5/swagger-play2/test-resources/delegated.routes
+++ b/play-2.5/swagger-play2/test-resources/delegated.routes
@@ -1,0 +1,4 @@
+->  /subdelegated     subdelegated.Routes
+
+GET    /my/action        testdata.DelegatedController.list
+GET    /all              testdata.DelegatedController.list2

--- a/play-2.5/swagger-play2/test-resources/delegation
+++ b/play-2.5/swagger-play2/test-resources/delegation
@@ -1,0 +1,1 @@
+->    /api      delegated.Routes

--- a/play-2.5/swagger-play2/test-resources/subdelegated.routes
+++ b/play-2.5/swagger-play2/test-resources/subdelegated.routes
@@ -1,0 +1,3 @@
+GET    /my/action        testdata.DelegatedController.list3
+GET    /all              testdata.DelegatedController.list4
+GET    /                 testdata.DelegatedController.list5

--- a/play-2.5/swagger-play2/test/PlayApiScannerSpec.scala
+++ b/play-2.5/swagger-play2/test/PlayApiScannerSpec.scala
@@ -1,17 +1,20 @@
 import java.io.File
 
-import play.modules.swagger._
-import org.specs2.mutable._
 import org.specs2.mock.Mockito
-import scala.collection.JavaConversions._
+import org.specs2.mutable._
+import org.specs2.specification.BeforeAfterAll
+import play.modules.swagger._
 import play.modules.swagger.util.SwaggerContext
-import play.routes.compiler.{ Route => PlayRoute }
+import play.routes.compiler.{Route => PlayRoute}
 
-class PlayApiScannerSpec extends Specification with Mockito {
+import scala.collection.JavaConversions._
+
+class PlayApiScannerSpec extends Specification with Mockito with BeforeAfterAll {
 
   // set up mock for Play Router
-  val routesList = {
-    play.routes.compiler.RoutesFileParser.parseContent("""
+  val routesList: List[PlayRoute] =
+    play.routes.compiler.RoutesFileParser.parseContent(
+"""
 GET /api/dog testdata.DogController.list
 PUT /api/dog testdata.DogController.add1
 GET /api/cat @testdata.CatController.list
@@ -19,30 +22,25 @@ PUT /api/cat @testdata.CatController.add1
 GET /api/fly testdata.FlyController.list
 PUT /api/dog testdata.DogController.add1
 PUT /api/dog/:id testdata.DogController.add0(id:String)
-                                                       """, new File("")).right.get.collect {
-      case (route: PlayRoute) => {
-        val routeName = s"${route.call.packageName}.${route.call.controller}$$.${route.call.method}"
-        route
-      }
-    }
+""", new File("")).right.get.collect { case (route: PlayRoute) => route}
+
+
+  val routesRules = Map(routesList map { route =>
+      s"${route.call.packageName}.${route.call.controller}$$.${route.call.method}" -> route
+  }: _*)
+
+
+  override def afterAll(): Unit = {}
+
+  override def beforeAll(): Unit = {
+    RouteFactory.setRoute(new RouteWrapper(routesRules))
   }
 
-  val routesRules = Map(routesList map 
-  { route =>
-    {
-      val routeName = s"${route.call.packageName}.${route.call.controller}$$.${route.call.method}"
-      routeName -> route
-    }
-  } : _*)
-
-
-  val route = new RouteWrapper(routesRules)
-  RouteFactory.setRoute(route)
 
   "PlayApiScanner" should {
     "identify correct API classes based on router and API annotations" in {
       val classes = new PlayApiScanner().classes()
-      
+
       classes.toList.length must beEqualTo(2)
       classes.contains(SwaggerContext.loadClass("testdata.DogController")) must beTrue
       classes.contains(SwaggerContext.loadClass("testdata.CatController")) must beTrue

--- a/play-2.5/swagger-play2/test/PlayDelegatedApiScannerSpec.scala
+++ b/play-2.5/swagger-play2/test/PlayDelegatedApiScannerSpec.scala
@@ -1,0 +1,48 @@
+import io.swagger.config.ScannerFactory
+import org.specs2.mock.Mockito
+import org.specs2.mutable._
+import org.specs2.specification.BeforeAfterAll
+import play.modules.swagger._
+import play.routes.compiler.Route
+
+import scala.collection.JavaConverters._
+
+class PlayDelegatedApiScannerSpec extends Specification with Mockito with BeforeAfterAll {
+
+  val routes: List[Route] =
+    SwaggerPluginHelper.parseRoutes("delegation", "", _ => {}, Thread.currentThread().getContextClassLoader)
+
+
+  val routesRules: Map[String, Route] = Map(routes.map { route: Route =>
+    s"${route.call.packageName}.${route.call.controller}$$.${route.call.method}" -> route
+  }: _*)
+
+
+  val swaggerConfig = new PlaySwaggerConfig()
+  swaggerConfig.setBasePath("")
+  swaggerConfig.setHost("127.0.0.1")
+
+  override def afterAll(): Unit = {}
+
+  override def beforeAll(): Unit = {
+    ApiListingCache.cache = None
+    PlayConfigFactory.setConfig(swaggerConfig)
+    ScannerFactory.setScanner(new PlayApiScanner())
+    RouteFactory.setRoute(new RouteWrapper(routesRules.asJava))
+  }
+
+
+  "route parsing" should {
+    "separate delegated paths correctly" in {
+
+      val urls = ApiListingCache.listing("", "127.0.0.1").get.getPaths.keySet().asScala
+
+      urls must contain("/api/all")
+      urls must contain("/api/my/action")
+      urls must contain("/api/subdelegated/all")
+      urls must contain("/api/subdelegated/my/action")
+      urls must contain("/api/subdelegated")
+    }
+  }
+
+}

--- a/play-2.5/swagger-play2/test/testdata/DelegatedController.scala
+++ b/play-2.5/swagger-play2/test/testdata/DelegatedController.scala
@@ -1,0 +1,24 @@
+package testdata
+
+import io.swagger.annotations.{Api, ApiOperation}
+import play.api.mvc.{Action, Controller}
+
+@Api
+object DelegatedController extends Controller {
+
+  @ApiOperation(value = "list")
+  def list = Action { _ => Ok("test case")}
+
+  @ApiOperation(value = "list2")
+  def list2 = Action { _ => Ok("test case")}
+
+  @ApiOperation(value = "list3")
+  def list3 = Action { _ => Ok("test case")}
+
+  @ApiOperation(value = "list4")
+  def list4 = Action { _ => Ok("test case")}
+
+  @ApiOperation(value = "list5")
+  def list5 = Action { _ => Ok("test case")}
+
+}


### PR DESCRIPTION
When a set of routes is delegated to another router, there is a missing "/" between the prefix of the delegated route and the last part of the route.

For instance:

```
->       /endpoint        myEndpoint.router.Routes
```

and in the myEndpoint.router.routes:


```
GET    /my/endpoint     ....
```

would end up with url /endpointmy/endpoint insead of /endpoint/my/endpoint