### PR TITLE
Add support for dataTypeClass for implicit params

### DIFF
--- a/play-2.5/swagger-play2/app/play/modules/swagger/PlayReader.java
+++ b/play-2.5/swagger-play2/app/play/modules/swagger/PlayReader.java
@@ -365,6 +365,15 @@ public class PlayReader {
         }
     }
 
+    private Type getDataType(final ApiImplicitParam param, Class<?> cls, String typeString) {
+        Type type = null;
+        // Swagger ReflectionUtils can't handle file or array datatype
+        if (!"".equalsIgnoreCase(typeString) && !"file".equalsIgnoreCase(typeString) && !"array".equalsIgnoreCase(typeString)){
+            type = typeFromString(typeString, cls);
+        }
+        return type;
+    }
+
     protected io.swagger.models.parameters.Parameter readImplicitParam(ApiImplicitParam param, Class<?> cls) {
         final Parameter p;
         if (param.paramType().equalsIgnoreCase("path")) {
@@ -381,12 +390,9 @@ public class PlayReader {
             Logger.warn("Unkown implicit parameter type: [" + param.paramType() + "]");
             return null;
         }
-        Type type = null;
-        // Swagger ReflectionUtils can't handle file or array datatype
-        if (!"".equalsIgnoreCase(param.dataType()) && !"file".equalsIgnoreCase(param.dataType()) && !"array".equalsIgnoreCase(param.dataType())){
-            type = typeFromString(param.dataType(), cls);
 
-        }
+        Type type = getDataType(param, cls, param.dataType().equals("") ? param.dataTypeClass().getCanonicalName() : param.dataType());
+
         Parameter result =  ParameterProcessor.applyAnnotations(getSwagger(), p, type == null ? String.class : type, Collections.singletonList(param));
 
         if (result instanceof AbstractSerializableParameter && type != null) {

--- a/play-2.5/swagger-play2/app/play/modules/swagger/PlayReader.java
+++ b/play-2.5/swagger-play2/app/play/modules/swagger/PlayReader.java
@@ -365,15 +365,6 @@ public class PlayReader {
         }
     }
 
-    private Type getDataType(final ApiImplicitParam param, Class<?> cls, String typeString) {
-        Type type = null;
-        // Swagger ReflectionUtils can't handle file or array datatype
-        if (!"".equalsIgnoreCase(typeString) && !"file".equalsIgnoreCase(typeString) && !"array".equalsIgnoreCase(typeString)){
-            type = typeFromString(typeString, cls);
-        }
-        return type;
-    }
-
     protected io.swagger.models.parameters.Parameter readImplicitParam(ApiImplicitParam param, Class<?> cls) {
         final Parameter p;
         if (param.paramType().equalsIgnoreCase("path")) {
@@ -391,7 +382,12 @@ public class PlayReader {
             return null;
         }
 
-        Type type = getDataType(param, cls, param.dataType().equals("") ? param.dataTypeClass().getCanonicalName() : param.dataType());
+        Type type = null;
+        if (!"".equalsIgnoreCase(param.dataType()) && !"file".equalsIgnoreCase(param.dataType()) && !"array".equalsIgnoreCase(param.dataType())){
+            type = typeFromString(param.dataType(), cls);
+        } else if (param.dataTypeClass() != null && !isVoid(param.dataTypeClass())) {
+            type = param.dataTypeClass();
+        }
 
         Parameter result =  ParameterProcessor.applyAnnotations(getSwagger(), p, type == null ? String.class : type, Collections.singletonList(param));
 

--- a/play-2.5/swagger-play2/build.sbt
+++ b/play-2.5/swagger-play2/build.sbt
@@ -10,7 +10,7 @@ crossScalaVersions := Seq("2.10.6", scalaVersion.value, "2.12.1")
 libraryDependencies ++= Seq(
   "com.fasterxml.jackson.module"  %% "jackson-module-scala"       % "2.8.6",
   "org.slf4j"          % "slf4j-api"                  % "1.7.21",
-  "io.swagger"         % "swagger-core"               % "1.5.12",
+  "io.swagger"         % "swagger-core"               % "1.5.13",
   "io.swagger"        %% "swagger-scala-module"       % "1.0.3",
   "com.typesafe.play" %% "routes-compiler"            % "2.5.4",
   "com.typesafe.play" %% "play-ebean"                 % "2.0.0"            % "test",

--- a/play-2.5/swagger-play2/test/PlayApiListingCacheSpec.scala
+++ b/play-2.5/swagger-play2/test/PlayApiListingCacheSpec.scala
@@ -22,7 +22,7 @@ POST /api/document/:settlementId/files/:fileId/accept testdata.DocumentControlle
 GET /api/search testdata.SettlementsSearcherController.search(personalNumber:String,propertyId:String)
 GET /api/pointsofinterest testdata.PointOfInterestController.list(eastingMin:Double,northingMin:Double,eastingMax:Double,northingMax:Double)
 GET /api/dog testdata.DogController.list
-PUT /api/dog testdata.DogController.add1
+PUT /api/dog testdata.DogController.add4
 GET /api/cat @testdata.CatController.list
 GET /api/cat43 @testdata.CatController.testIssue43(test_issue_43_param: Option[Int])
 PUT /api/cat @testdata.CatController.add1
@@ -162,7 +162,7 @@ PUT /api/dog/:id testdata.DogController.add0(id:String)
       opDogGet.getProduces.asScala.toList must beEqualTo(List("application/json","application/xml"))
 
       val opDogPut = pathDog.getOperationMap.get(HttpMethod.PUT)
-      opDogPut.getOperationId must beEqualTo("add1")
+      opDogPut.getOperationId must beEqualTo("add4")
       opDogPut.getParameters.head.getName must beEqualTo("dog")
       opDogPut.getParameters.head.getIn must beEqualTo("body")
       opDogPut.getParameters.head.asInstanceOf[BodyParameter].getSchema.getReference must beEqualTo("#/definitions/Dog")

--- a/play-2.5/swagger-play2/test/testdata/DogController.scala
+++ b/play-2.5/swagger-play2/test/testdata/DogController.scala
@@ -75,6 +75,15 @@ object DogController extends Controller {
     request => Ok("test case")
   }
 
+  @ApiResponses(Array(
+    new ApiResponse(code = 405, message = "Invalid input"),
+    new ApiResponse(code = 666, message = "Big Problem")))
+  @ApiImplicitParams(Array(
+    new ApiImplicitParam(name = "dog", value = "Dog object to add", required = true, dataTypeClass = classOf[testdata.Dog], paramType = "body")))
+  def add4 = Action {
+    request => Ok("test case")
+  }
+
   @ApiOperation(value = "Updates a new Dog",
     notes = "Updates dogs nicely",
     httpMethod = "POST")


### PR DESCRIPTION
`swagger-core` v. `1.5.13` supports the `dataTypeClass` parameter in the `ApiImplicitParam` annotation. This extracts that argument when inferring the API param type.