### PR TITLE
Load routes safely in SwaggerPlugin

### DIFF
--- a/play-2.4/swagger-play2/app/play/modules/swagger/SwaggerPlugin.scala
+++ b/play-2.4/swagger-play2/app/play/modules/swagger/SwaggerPlugin.scala
@@ -29,6 +29,7 @@ import scala.collection.JavaConversions._
 import play.routes.compiler.{Route => PlayRoute, Include => PlayInclude, RoutesFileParser, StaticPart}
 
 import scala.io.Source
+import scala.util.control.NonFatal
 
 trait SwaggerPlugin
 
@@ -116,7 +117,7 @@ class SwaggerPluginImpl @Inject()(lifecycle: ApplicationLifecycle, router: Route
       }
     }
     //Parses multiple route files recursively
-    def parseRoutesHelper(routesFile: String, prefix: String): List[PlayRoute] = {
+    def parseRoutesHelper(routesFile: String, prefix: String): List[PlayRoute] = try {
       logger.debug(s"Processing route file '$routesFile' with prefix '$prefix'")
 
       val routesContent = Source.fromInputStream(app.classloader.getResourceAsStream(routesFile)).mkString
@@ -136,7 +137,12 @@ class SwaggerPluginImpl @Inject()(lifecycle: ApplicationLifecycle, router: Route
       }.flatten
       logger.debug(s"Finished processing route file '$routesFile'")
       routes
+    } catch {
+      case NonFatal(e) =>
+        logger.debug(s"Unable to parse routes from $routesFile", e)
+        Nil
     }
+    
     parseRoutesHelper(routesFile, "")
   }
 

--- a/play-2.5/swagger-play2/app/play/modules/swagger/SwaggerPlugin.scala
+++ b/play-2.5/swagger-play2/app/play/modules/swagger/SwaggerPlugin.scala
@@ -29,6 +29,7 @@ import scala.collection.JavaConversions._
 import play.routes.compiler.{Route => PlayRoute, Include => PlayInclude, RoutesFileParser, StaticPart}
 
 import scala.io.Source
+import scala.util.control.NonFatal
 
 trait SwaggerPlugin
 
@@ -116,7 +117,7 @@ class SwaggerPluginImpl @Inject()(lifecycle: ApplicationLifecycle, router: Route
       }
     }
     //Parses multiple route files recursively
-    def parseRoutesHelper(routesFile: String, prefix: String): List[PlayRoute] = {
+    def parseRoutesHelper(routesFile: String, prefix: String): List[PlayRoute] = try {
       logger.debug(s"Processing route file '$routesFile' with prefix '$prefix'")
 
       val routesContent =  Source.fromInputStream(app.classloader.getResourceAsStream(routesFile)).mkString
@@ -133,7 +134,12 @@ class SwaggerPluginImpl @Inject()(lifecycle: ApplicationLifecycle, router: Route
       }.flatten
       logger.debug(s"Finished processing route file '$routesFile'")
       routes
+    } catch {
+      case NonFatal(e) =>
+        logger.debug(s"Unable to parse routes from $routesFile", e)
+        Nil
     }
+    
     parseRoutesHelper(routesFile, "")
   }
 


### PR DESCRIPTION
I have a router that extends `SimpleRouter`:
```scala
class ApiRouter(controller: ApiController) extends SimpleRouter
{
  override def routes: Routes = {
    case GET(p"/") => controller.index
  }
}
```
And my routes file:

```
->         /                  ApiRouter
```

However when SwaggerPlugin loads the routes during the app initialization, it tries to load `ApiRouter` as a file thus throwing NullPointerException at the following code:

```scala
Source.fromInputStream(app.classloader.getResourceAsStream(routesFile)).mkString
```

This PR ignores any exceptions when loading routes and logs in debug level.