### PR TITLE
ReadMe for Play 2.5 support

### DIFF
--- a/play-2.5/swagger-play2/README.md
+++ b/play-2.5/swagger-play2/README.md
@@ -7,6 +7,8 @@ This is a module to support the play2 framework from [playframework](http://www.
 
 ## Version History
 
+* swagger-play2 1.5.3 supports play 2.5 and swagger 2.0.  
+
 * swagger-play2 1.5.1 supports play 2.4 and swagger 2.0.  If you need swagger 1.2 support, use 1.3.13. If you need 2.2 support, use 1.3.7 or earlier.
 
 * swagger-play2 1.3.13 supports play 2.4.  If you need 2.2 support, use 1.3.7 or earlier.

--- a/play-2.5/swagger-play2/README.md
+++ b/play-2.5/swagger-play2/README.md
@@ -5,7 +5,7 @@
 ## Overview
 This is a module to support the play2 framework from [playframework](http://www.playframework.org).  It is written in scala but can be used with either java or scala-based play2 applications.
 
-## Version History
+## Version Support
 
 * swagger-play2 1.5.3 supports play 2.5 and swagger 2.0.  
 

--- a/play-2.5/swagger-play2/README.md
+++ b/play-2.5/swagger-play2/README.md
@@ -5,6 +5,9 @@
 ## Overview
 This is a module to support the play2 framework from [playframework](http://www.playframework.org).  It is written in scala but can be used with either java or scala-based play2 applications.
 
+## Swagger Samples
+For an example of using `swagger-play` with Play 2.4, see [swagger-samples](https://github.com/swagger-api/swagger-samples).
+
 ## Version Support
 
 * swagger-play2 1.5.3 supports play 2.5 and swagger 2.0.  


### PR DESCRIPTION
There is much confusion from this and open issues still.

See:
- https://github.com/swagger-api/swagger-play/issues/67#issuecomment-294835498
- https://github.com/swagger-api/swagger-play/issues/95

_ _ _

The second bullet is still confusing:

>  * swagger-play2 1.5.1 supports play 2.4 and swagger 2.0.  If you need swagger 1.2 support, use 1.3.13. If you need 2.2 support, use 1.3.7 or earlier.