### PR TITLE
Correct content-length generation for JSON

### DIFF
--- a/play-2.6/swagger-play2/app/controllers/ApiHelpController.scala
+++ b/play-2.6/swagger-play2/app/controllers/ApiHelpController.scala
@@ -204,8 +204,8 @@ trait SwaggerBaseApiController {
     val jsonBytes = toJsonString(data).getBytes("UTF-8")
     val source = Source.single(jsonBytes).map(ByteString.apply)
     Result (
-      header = ResponseHeader(200, Map(HeaderNames.CONTENT_LENGTH -> jsonBytes.length.toString)),
-      body = HttpEntity.Streamed(source, None, None)
-    ).as ("application/json")
+      header = ResponseHeader(200, Map.empty),
+      body = HttpEntity.Streamed(source, Some(jsonBytes.length), Some("application/json"))
+    )
   }
 }


### PR DESCRIPTION
Use correct HttpEntity to report Content-Length. 

The problem became substantial when the swagger.json is accessed through an API gateway (e.g. AWS load balancer) where proper content-length header is required to properly close the connection.

Without this fix, the following warning is shown on the Play console when the swagger json is requested.

`[WARN] [05/24/2018 18:03:09.086] [play-dev-mode-akka.actor.default-dispatcher-2] [akka.actor.ActorSystemImpl(play-dev-mode)] Explicitly set HTTP header 'Content-Length: 11163' is ignored, explicit `Content-Length` header is not allowed. Use the appropriate HttpEntity subtype.
`