### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/play-1.2/commands.py
+++ b/play-1.2/commands.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Here you can create play commands that are specific to the module, and extend existing commands
 
 MODULE = 'swagger-play'
@@ -13,7 +14,7 @@ def execute(**kargs):
     env = kargs.get("env")
 
     if command == "swagger-play:hello":
-        print "~ Hello"
+        print("~ Hello")
 
 
 # This will be executed before any command (new, run...)


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.