### PR TITLE
Basic Auth Implementation for swagger play

### DIFF
--- a/play-2.6/swagger-play2/app/play/modules/swagger/PlayReader.java
+++ b/play-2.6/swagger-play2/app/play/modules/swagger/PlayReader.java
@@ -323,7 +323,13 @@ public class PlayReader {
             swagger.addSecurityDefinition(apiKeyAuthConfig.key(), apiKeyAuthDefinition);
         }
 
+        for (BasicAuthDefinition basicAuthConfig:config.securityDefinition().basicAuthDefinitions()) {
 
+            io.swagger.models.auth.BasicAuthDefinition basicAuthDefinition = new io.swagger.models.auth.BasicAuthDefinition();
+            basicAuthDefinition.setDescription(basicAuthConfig.description());
+
+            swagger.addSecurityDefinition(basicAuthConfig.key(), basicAuthDefinition);
+        }
 
         for (SwaggerDefinition.Scheme scheme : config.schemes()) {
             if (scheme != SwaggerDefinition.Scheme.DEFAULT) {

--- a/play-2.6/swagger-play2/test/PlayApiListingCacheSpec.scala
+++ b/play-2.6/swagger-play2/test/PlayApiListingCacheSpec.scala
@@ -87,7 +87,7 @@ PUT /api/dog/api/:id testdata.DogController.add0(id:String)
       swagger.get.getInfo.getTitle must beEqualTo(swaggerConfig.getTitle)
       swagger.get.getInfo.getTermsOfService must beEqualTo(swaggerConfig.getTermsOfServiceUrl)
       swagger.get.getInfo.getLicense.getName must beEqualTo(swaggerConfig.getLicense)
-      swagger.get.getSecurityDefinitions.size() must beEqualTo(2)
+      swagger.get.getSecurityDefinitions.size() must beEqualTo(3)
 
       val pathDoc = swagger.get.getPaths.get("/document/{settlementId}/files/{fileId}/accept")
       pathDoc.getOperations.size must beEqualTo(1)

--- a/play-2.6/swagger-play2/test/testdata/CatController.scala
+++ b/play-2.6/swagger-play2/test/testdata/CatController.scala
@@ -17,10 +17,21 @@ import play.api.mvc.{Action, Controller}
         authorizationUrl = "/authorize",
         scopes = Array(new Scope(name = "write_pets", description = "modify pets"))
       )
-    )
+    ),
+    basicAuthDefinitions = Array(new BasicAuthDefinition(key = "basic_auth"))
   )
 )
-@Api(value = "/apitest/cats", description = "play with cats")
+@Api(value = "/apitest/cats", description = "play with cats", authorizations = Array (
+  new Authorization(
+    value = "oauth2"
+  ),
+  new Authorization(
+    value = "api_key"
+  ),
+  new Authorization(
+    value = "basic_auth"
+  )
+))
 class CatController extends Controller {
 
   @ApiOperation(value = "addCat1",
@@ -76,7 +87,7 @@ class CatController extends Controller {
   @ApiOperation(value = "test issue #43",
     nickname = "test issue #43_nick",
     notes = "test issue #43_notes",
-    response = classOf[testdata.Cat],
+    response = classOf[Cat],
     responseContainer = "List",
     httpMethod = "GET")
   @ApiImplicitParams(Array(


### PR DESCRIPTION
Description:
This PR includes basic auth support for play2.6 and resolves #120 .

1. Added implementation for basic auth security definitions
2. Added basic security definition for CatController test cases
3. Refactored test cases