### PR TITLE
Avoid localhost:9000 as a default host value

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -4,7 +4,7 @@ api.version = beta
 swagger.filter = null
 swagger.api {
   basepath = "/"
-  host = "localhost:9000"
+  host = ""
   title = ""
   schemes = []
 


### PR DESCRIPTION
Fixes #224.
`localhost:9000` as a default configuration value forces to override it in 99% cases.
How about having an empty string?